### PR TITLE
Update README to reflect changes of the new v2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,14 +273,14 @@ class UserRepository {
 
 // configureDI.ts
 import { createConnections } from "my-orm-library";
-import DIContainer, { factory, use, IDIContainer } from "rsdi";
+import DIContainer, { factory, use } from "rsdi";
 
 async function configureDI() {
     // initialize async factories before DI container initialisation
     const dbConnection = await createConnections();
 
     const container = new DIContainer();
-    container.addDefinitions({
+    container.add({
         DbConnection: dbConnection,
         UserRepository: object(UserRepository).construct(use("DbConnection")),
     });


### PR DESCRIPTION
Last example still used `container.addDefinitions(...) ` which is no longer part of the `DIContainer` class in the new v2. Also the IDIContainer interface was imported but not used.

**Suggestion**: Add a little notification at the top of the readme to let users know what changed between the new v2 and prior releases.