### PR TITLE
perf(types): compose large containers instead of one O(N²) add chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,36 @@ jobs:
       - name: Test
         run: pnpm test
 
+  # The type tests assert inference at three or four dependencies, which is far
+  # too small to notice the two ways this package's types fail: a per-dependency
+  # cost multiplying everyone's build time, and a depth-limiter trip that collapses
+  # inference to `never` past ~50 dependencies. Both pass the full test suite. This
+  # job checks the shapes big enough to expose them.
+  types-perf:
+    name: Type-checking budget
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check type-instantiation budgets
+        run: pnpm bench:types
+
   # The matrix above can't reach `engines.node` — Vitest needs a far newer
   # runtime than the floor — so without this job the floor is an unverified
   # claim. This imports the built `dist/` the way a consumer would, on exactly
@@ -116,7 +146,7 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [lint, test, min-node]
+    needs: [lint, test, types-perf, min-node]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs succeeded

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Type tests only run when `--typecheck` is passed, so a bare `npx vitest --run` s
 
 There is no separate typecheck script — `pnpm test` runs both runtime tests and type tests in one pass. Always run `pnpm build`, `pnpm test`, and `pnpm lint` before considering a change done; CI (`.github/workflows/ci.yml`) runs `pnpm build` + `pnpm lint` in one job and `pnpm test` across a Node matrix in another, with an aggregate `CI` job as the single required status check.
 
-**Run `pnpm bench:types` too whenever you touch `src/types.ts` or an `add`/`merge`/`compose` signature.** The type tests assert inference at three or four dependencies, which is too small to expose how these types actually fail — both known failure modes pass the full 82-test suite untouched. `scripts/bench-types.mjs` checks the shapes that are big enough, and gates them on instantiation budgets; it runs in CI as the `types-perf` job. Budgets are compiler-specific, so a TypeScript upgrade needs them re-baselined in the same commit.
+**Run `pnpm bench:types` too whenever you touch `src/types.ts` or an `add`/`merge`/`compose` signature.** The type tests assert inference at three or four dependencies, which is too small to expose how these types actually fail — both known failure modes pass the full 82-test suite untouched. `scripts/bench-types.mjs` checks the shapes that are big enough, and gates them on instantiation budgets; it runs in CI as the `types-perf` job. Budgets are compiler-specific, so a TypeScript upgrade needs them re-baselined in the same commit. `docs/type-benchmarks.md` explains how to read the report and what to do with each kind of failure.
 
 ## Source layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,15 @@ Use **pnpm** (pinned via `packageManager`; do not use npm/yarn).
 | Single test case     | `npx vitest --run -t 'merge containers'`              |
 | Lint (check)         | `pnpm lint`                                           |
 | Format + autofix     | `pnpm format`                                         |
+| Type-cost budgets    | `pnpm bench:types`                                    |
 
 `pnpm lint` runs `oxfmt --check` then `oxlint --type-aware --type-check`; `pnpm format` runs the same two tools in write/`--fix` mode.
 
 Type tests only run when `--typecheck` is passed, so a bare `npx vitest --run` silently skips every `*.test-d.ts` assertion. `pnpm test` includes it; ad-hoc filtered runs need it added back.
 
 There is no separate typecheck script — `pnpm test` runs both runtime tests and type tests in one pass. Always run `pnpm build`, `pnpm test`, and `pnpm lint` before considering a change done; CI (`.github/workflows/ci.yml`) runs `pnpm build` + `pnpm lint` in one job and `pnpm test` across a Node matrix in another, with an aggregate `CI` job as the single required status check.
+
+**Run `pnpm bench:types` too whenever you touch `src/types.ts` or an `add`/`merge`/`compose` signature.** The type tests assert inference at three or four dependencies, which is too small to expose how these types actually fail — both known failure modes pass the full 82-test suite untouched. `scripts/bench-types.mjs` checks the shapes that are big enough, and gates them on instantiation budgets; it runs in CI as the `types-perf` job. Budgets are compiler-specific, so a TypeScript upgrade needs them re-baselined in the same commit.
 
 ## Source layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ Factories receive `this.context`, a `Proxy` built in the constructor that forwar
 ## Publishing
 
 - `prepublishOnly` runs `pnpm build`, so `dist/` is always fresh on publish.
-- `files` publishes `dist/**` but excludes `dist/**/__tests__/**` — compiled tests are not shipped.
+- `files` publishes `dist/**` but excludes `dist/**/__tests__/**` — compiled tests are not shipped. It also ships `docs/ai-agent-guide.md`, so an AI agent working in a consumer's project can read the integration guide straight out of `node_modules`; that file is the only doc that ships, so any link in it to another doc must be an absolute GitHub URL rather than a relative path.
 - License is **Apache-2.0** (matches the `LICENSE` file).
 
 - **The package is ESM-only and that is deliberate**, not a limitation — nothing in `src/` requires it (no `import.meta`, no top-level await). CommonJS consumers are not shut out: Node 20.19+ and 22.12+ resolve `require()` of an ESM package, so the effective floor for a CJS consumer is Node 20.19 even though `engines.node` says 16.9. TypeScript CJS consumers need `module: nodenext`; on `Node16` they get `TS1479`. Dual-publishing CJS has been considered and rejected — it doubles the build and invites the dual package hazard, where two loaded copies make `instanceof DIContainer` fail.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,11 +65,11 @@ Because of that intersection, a dependency called `get` would shadow the `get` m
 - **Compile time** — `DenyInputKeys` / `StringLiteral` in `types.ts` reject non-literal and colliding names.
 - **Runtime** — the `containerMethods` `Set` at the top of `DIContainer.ts` throws `ForbiddenNameError`.
 
-Adding a public method to the class means adding its name to that `Set`.
+Adding a public **instance** method to the class means adding its name to that `Set`. Static members (`DIContainer.compose`) are exempt — they never live on the instance, so a dependency cannot shadow them.
 
 ### Mutation is real; immutability is only in the types
 
-`add`, `update`, and `merge` all mutate `this` and return it re-cast. Despite the JSDoc on `merge` saying it returns a new container, it does not — it writes into `this.resolvers` and returns `this`. `clone()` is the only method that produces a genuinely separate instance.
+`add`, `update`, and `merge` all mutate `this` and return it re-cast — `merge` writes into `this.resolvers` and returns `this`. `clone()` and the static `DIContainer.compose()` are the only ways to get a genuinely separate instance; `compose` builds a fresh container and merges each input into it, leaving the inputs untouched.
 
 `clone()` works through `ClonedDiContainer`, a non-exported subclass at the bottom of `DIContainer.ts`. It exists purely to provide a constructor that seeds resolvers, because the public `DIContainer` constructor deliberately takes no arguments. `setResolvers` is `protected` for the same reason and throws if resolvers already exist.
 
@@ -107,6 +107,8 @@ Factories receive `this.context`, a `Proxy` built in the constructor that forwar
 - **Keep runtime dependencies at zero.** Never add a `dependencies` entry. Dev-only tooling goes in `devDependencies`.
 
 - **Resolvers are lazy and cached.** `add(name, factory)` registers a factory; it runs once on first `get`/property access, then the result is cached. `add` throws if the name already exists — use `update` to replace (mainly for test mocking). Reserved container method names (`add`, `get`, `merge`, …) cannot be used as dependency names.
+
+- **Composition is the answer to slow type-checking, and it is load-bearing.** A single `.add()` chain of N dependencies costs O(N²) to check (1600 deps ≈ 90 s); the same graph split into modules and combined with `DIContainer.compose()` checks in under a second. `MergedResolvers` in `types.ts` deliberately uses a union-to-intersection fold — a recursive tuple fold trips TS2589 at ~50 containers and silently degrades inference to `never`. Likewise `ResolversOf` must test the `DIContainer` class branch **before** the `IDIContainer` branch, since a class instance also matches `IDIContainer` structurally. Both constraints are covered by type tests; see `docs/type-performance-plan.md` for the measurements.
 
 ## Toolchain pins (don't casually bump)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ src/
   DIContainer.ts   # the container class (add/get/update/merge/clone/extend/has/…)
   types.ts         # public + internal type machinery (IDIContainer, Factory, …)
   errors.ts        # typed error classes
-  index.ts         # public entry point — exports DIContainer, IDIContainer
+  index.ts         # public entry point — exports DIContainer, IDIContainer, ResolversOf, SealedContainer
   __tests__/
     *.test.ts                     # runtime tests (vitest)
     __typetests__/*.test-d.ts     # TYPE tests (vitest expectTypeOf, needs --typecheck)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Manage your dependencies with ease and safety. RSDI is a minimal, powerful DI co
 - [Strict types](#strict-types)
 - [Advanced Usage](#advanced-usage)
   - [Extend](#extend)
+  - [Compose](#compose)
   - [Merge](#merge)
   - [Clone](#clone)
   - [Other methods](#other-methods)
@@ -46,6 +47,7 @@ RSDI avoids this by using explicit factory functions — keeping your code clean
 - Simple API
 - No runtime dependencies
 - Easy to mock and test
+- Scales to large graphs — [compose](#compose) independent modules instead of one long chain
 
 ## Installation
 
@@ -260,12 +262,56 @@ export const addValidators = (container: DIWithPool) => {
 
 ---
 
+### Compose
+
+`DIContainer.compose()` combines independently built containers into one new container. It is the recommended way to
+wire a large dependency graph, and it keeps the inputs untouched.
+
+```ts
+// repositories.ts
+export const repositories = new DIContainer().add('userRepository', () => new UserRepository());
+
+// services.ts — declare what this module expects the composed container to provide
+export const services = new DIContainer<{ userRepository: UserRepository }>().add(
+  'userService',
+  ({ userRepository }) => new UserService(userRepository),
+);
+
+// container.ts
+const container = DIContainer.compose(repositories, services);
+
+container.userService; // UserService — fully typed
+```
+
+Resolution stays lazy and happens against the composed container, so a factory may depend on names provided by any of
+the composed modules. Only the _types_ of a module are limited to what that module declares — annotate the module (as
+`services` does above) or use `.extend()` when you need another module's types to be visible while writing it.
+
+If several containers define the same name, the last one wins.
+
+#### Why compose instead of one long chain
+
+Each `.add()` widens the container type, so a single chain of N dependencies costs **O(N²)** to type-check. Splitting
+the graph into modules keeps each chain short, and the compiler only pays the quadratic within a module. Measured with
+TypeScript 7 on this repo's benchmark (1600 dependencies, no factory arguments):
+
+| Layout                         | Type instantiations | Check time |
+| ------------------------------ | ------------------: | ---------: |
+| one chain of 1600              |           7,815,223 |     90.2 s |
+| 80 modules of 20, then compose |             361,552 |      0.9 s |
+
+That is ~22× fewer instantiations and ~100× faster. If your editor feels sluggish in the file that wires your
+container, this is usually why.
+
+---
+
 ### Merge
 
-You can merge two containers to combine their resolvers and resolved values.
+You can merge containers to combine their resolvers and resolved values. Unlike `compose`, `merge` mutates and returns
+the container it is called on.
 
-- Dependencies from both containers are preserved.
-- If both define the same key, the merging container's value takes precedence.
+- Dependencies from all containers are preserved.
+- If several define the same key, the last one takes precedence.
 - Already resolved values are reused — not re-created.
 
 ```ts
@@ -279,6 +325,12 @@ console.log(finalContainer.a); // "1"
 console.log(finalContainer.b); // "b"
 console.log(finalContainer.bar instanceof Bar); // true
 console.log(finalContainer.buzz.name); // "buzz"
+```
+
+`merge` accepts several containers at once, which avoids a long chain of merges:
+
+```ts
+const finalContainer = base.merge(repositories, services, controllers);
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 Manage your dependencies with ease and safety. RSDI is a minimal, powerful DI container with full TypeScript support — no decorators or metadata required.
 
+> **Using an AI coding agent?** Point it at
+> **[docs/ai-agent-guide.md](./docs/ai-agent-guide.md)** — a single-page integration guide covering
+> the API, the mistakes that don't compile, how to structure a large container, and how to decode
+> RSDI's error messages. Every example in it is compile- and runtime-verified.
+
 - [Motivation](#motivation)
 - [Features](#features)
 - [Installation](#installation)
@@ -20,6 +25,7 @@ Manage your dependencies with ease and safety. RSDI is a minimal, powerful DI co
   - [Clone](#clone)
   - [Naming your container type](#naming-your-container-type)
   - [Other methods](#other-methods)
+- [Further reading](#further-reading)
 
 ## Motivation
 
@@ -407,3 +413,18 @@ container.hasResolvedDependency('bar'); // false — not resolved yet
 container.get('bar');
 container.hasResolvedDependency('bar'); // true — now cached
 ```
+
+---
+
+## Further reading
+
+- **[AI agent integration guide](./docs/ai-agent-guide.md)** — one page an AI coding agent can read
+  before wiring RSDI into a project: API reference, the mistakes that fail to compile, how to
+  structure a large container, and how to decode each error.
+- [Async factory resolvers](./docs/async_factory_resolver.md) — why factories are synchronous, and
+  how to handle resources that need `await`.
+- [DI container vs context](./docs/context_vs_container.md) — why the container stays at the
+  composition root instead of being passed through your app.
+- [Strict types](./docs/strict_types.md) — what the compiler catches for you.
+- [Type-performance plan](./docs/type-performance-plan.md) — measurements behind the O(N²) chain
+  cost and the composition guidance, for contributors.

--- a/README.md
+++ b/README.md
@@ -267,6 +267,14 @@ export const addValidators = (container: DIWithPool) => {
 };
 ```
 
+> **On long chains, annotate the return type.** Deriving each module's input from the previous module's
+> output (`(c: ReturnType<typeof previousModule>) => …`) is tempting, but it keeps every module's type nested
+> inside the one before it, so instantiation depth accumulates down the whole chain and your build becomes
+> coupled to RSDI's internals. Past a handful of modules this shows up as `TS2589` or a container that
+> collapses to `never`. Give each module an explicit named return type — `(c: DIWithPool): DIWithValidators
+=> …` — so every boundary flattens the accumulated type. A [`SealedContainer`](#naming-your-container-type)
+> boundary every few modules gets most of the same benefit.
+
 ---
 
 ### Compose
@@ -309,6 +317,15 @@ TypeScript 7 on this repo's benchmark (1600 dependencies, no factory arguments):
 
 That is ~22× fewer instantiations and ~100× faster. If your editor feels sluggish in the file that wires your
 container, this is usually why.
+
+**Splitting alone is not the win — isolation is.** A module is cheap when it is checked against only the
+dependencies it declares it consumes. In a production app with ~340 dependencies, splitting a flat chain into
+`.extend()` modules that thread the whole accumulated container measured no better than the flat chain
+(3.41M → 3.48M instantiations); giving each leaf an explicit consumed-type seed and combining with `compose`
+made those leaves **~13× cheaper to check** (924.8 ms → 68.7 ms). Declare the seed as an explicit interface —
+`Pick<FullContainer, 'a' | 'b'>` forces TypeScript to normalise the entire accumulated map and couples the
+module to the whole graph. See the
+[AI agent integration guide](./docs/ai-agent-guide.md) for the full pattern.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -428,3 +428,5 @@ container.hasResolvedDependency('bar'); // true — now cached
 - [Strict types](./docs/strict_types.md) — what the compiler catches for you.
 - [Type-performance plan](./docs/type-performance-plan.md) — measurements behind the O(N²) chain
   cost and the composition guidance, for contributors.
+- [Reading `pnpm bench:types`](./docs/type-benchmarks.md) — how to interpret the type-cost gate,
+  for contributors.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Manage your dependencies with ease and safety. RSDI is a minimal, powerful DI co
   - [Compose](#compose)
   - [Merge](#merge)
   - [Clone](#clone)
+  - [Naming your container type](#naming-your-container-type)
   - [Other methods](#other-methods)
 
 ## Motivation
@@ -353,6 +354,38 @@ console.log(containerB.a); // "1"
 console.log(containerB.bar instanceof Bar); // true
 console.log(containerB.buzz.name); // "buzz"
 ```
+
+---
+
+### Naming your container type
+
+Consumer files usually want to refer to the built container by name:
+
+```ts
+export type AppDIContainer = ReturnType<typeof configureDI>;
+```
+
+That works, but TypeScript still expands it in diagnostics, so a container with a few hundred dependencies produces
+errors and hovers like `IDIContainer<{ a: string; } & { b: number; } & … }>`. Wrapping it in `SealedContainer` creates a
+fresh alias that TypeScript prints by name instead:
+
+```ts
+import { type SealedContainer } from 'rsdi';
+
+export type AppDIContainer = SealedContainer<ReturnType<typeof configureDI>>;
+
+// error messages and hovers now say `AppDIContainer`
+export function configureRouter(app: core.Express, container: AppDIContainer) {
+  const { userController } = container; // still fully typed
+}
+```
+
+The dependency types are unchanged — `container.userController` resolves exactly as before, and the container stays
+chainable.
+
+This is purely for readability. Referring to a container from another file is already cheap: in a 400-dependency graph,
+50 consumer files add only ~2.6K type instantiations each, and naming the type costs about 3% _more_, not less. Reach
+for it when your error messages get unreadable, not to speed up compilation — for that, see [Compose](#compose).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,10 @@ Resolution stays lazy and happens against the composed container, so a factory m
 the composed modules. Only the _types_ of a module are limited to what that module declares — annotate the module (as
 `services` does above) or use `.extend()` when you need another module's types to be visible while writing it.
 
-If several containers define the same name, the last one wins.
+If several containers define the same name, the last one wins at runtime — including over a value an
+earlier container had already resolved. Be aware the _types_ intersect rather than overwrite, so the
+same name registered with two different types resolves to `never` instead of the later type. That
+surfaces the collision rather than hiding it; if a replacement is intentional, use `.update()`.
 
 #### Why compose instead of one long chain
 
@@ -335,7 +338,9 @@ You can merge containers to combine their resolvers and resolved values. Unlike 
 the container it is called on.
 
 - Dependencies from all containers are preserved.
-- If several define the same key, the last one takes precedence.
+- If several define the same key, the last one takes precedence at runtime (and any value the
+  replaced resolver had already produced is evicted). Types intersect, so a key defined twice with
+  different types becomes `never`.
 - Already resolved values are reused — not re-created.
 
 ```ts

--- a/docs/ai-agent-guide.md
+++ b/docs/ai-agent-guide.md
@@ -131,8 +131,13 @@ Threading the container into business logic recreates the coupling DI is meant t
 **Split the graph into module files and combine them.** This is the recommended layout, and past a
 few dozen dependencies it is not optional — a single `.add()` chain costs **O(N²)** to type-check.
 Measured on TypeScript 7: 1600 dependencies in one chain takes **90 seconds** to check; the same
-graph as 80 modules combined with `compose` takes **0.9 seconds**. Aim for **20–40 dependencies per
-module**.
+graph as 80 modules combined with `compose` takes **0.9 seconds**.
+
+**Module size is not the lever — wiring the whole graph as one chain is.** A module of **64** `add`
+calls layered on a 300-key container type-checks comfortably (CI guards exactly that shape), and
+splitting it further barely pays: the same 64 dependencies cost 38.1K instantiations as one module
+and 36.3K split four ways, under 5%. So treat ~64 as a comfortable ceiling and choose module size
+for readability — long modules are harder to read long before they are hard to compile.
 
 ```ts
 // di/repositories.ts
@@ -317,7 +322,8 @@ resolved _before_ it keeps the old instance it was constructed with.
 - [ ] Every `add`/`update` second argument is a function.
 - [ ] No dependency uses a reserved name.
 - [ ] Async resources are awaited before the container is built.
-- [ ] More than ~40 dependencies → split into modules and `compose`.
+- [ ] The whole graph is not one `.add()` chain — it is split into modules and composed. Up to ~64
+      dependencies in a single module is fine; below that, size is a readability choice.
 - [ ] Each module declares the dependencies it consumes as an explicit interface — not
       `Pick<FullContainer, …>`, and not by inferring from the previous module with `ReturnType`.
 - [ ] Long `.extend()` chains give each module an explicit named return type.

--- a/docs/ai-agent-guide.md
+++ b/docs/ai-agent-guide.md
@@ -193,6 +193,71 @@ export const container = DIContainer.compose(repositories).extend(addValidators)
 Both patterns scale — measured at 800 dependencies, `compose` and `extend` are within the same order
 of magnitude of each other and ~10× cheaper than one flat chain.
 
+### What actually makes it cheap: isolation, not splitting
+
+This is the part that decides whether the restructuring pays off, and it is easy to get wrong.
+
+**A module is cheap when it is checked against only what it declares it consumes**, not when it
+merely lives in its own file. Splitting a flat chain into `.extend()` modules that thread the whole
+accumulated container through each step measures _no better than the flat chain_ — a production
+application with ~340 dependencies measured 3.41M instantiations flat and 3.48M after splitting that
+way. Giving each leaf an explicit consumed-type seed and combining with `compose` is what paid: the
+five leaf modules cost **68.7 ms** to check combined, versus **924.8 ms** as `extend` modules
+threading the accumulated type — **~13× cheaper**, because each leaf is checked against the handful
+of keys it declares instead of a ~300-key map.
+
+So: declare the seed.
+
+```ts
+// ✓ an explicit interface of exactly what this module consumes
+export const services = new DIContainer<{ userRepository: UserRepository; mailer: Mailer }>().add(
+  'userService',
+  ({ userRepository, mailer }) => new UserService(userRepository, mailer),
+);
+```
+
+```ts
+// ✗ Pick<> from the full container type — forces TypeScript to normalise the entire
+//   accumulated map just to select two keys, and couples the module to the whole graph
+export const services = new DIContainer<Pick<FullContainer, 'userRepository' | 'mailer'>>().add(
+  'userService',
+  ({ userRepository, mailer }) => new UserService(userRepository, mailer),
+);
+```
+
+The explicit interface was both faster and decoupled in the same measurement.
+
+### Don't chain `ReturnType<typeof previousModule>`
+
+For a long `.extend()` chain it is tempting to skip the boilerplate and let each module infer its
+input from the previous module's output:
+
+```ts
+// ✗ do not do this down a long chain
+import type { addRepositories } from './repositories.js';
+export const addServices = (c: ReturnType<typeof addRepositories>) => c.add(/* … */);
+```
+
+It looks better — no type to keep in sync, and the input cannot drift from the actual output. But it
+removes the boundary that keeps instantiation depth bounded: each module's type stays nested inside
+the previous one, so depth accumulates across the entire chain and your build becomes coupled to
+RSDI's internal instantiation depth. In the same application this turned a clean build into **208
+errors**, with the container collapsing to `never` and every `add` name reporting
+`parameter of type 'never'`.
+
+Give each module an explicit named return type instead — it collapses the accumulated type into a
+flat named boundary at every step:
+
+```ts
+// ✓ explicit named boundary
+export type DIWithRepositories = IDIContainer<{ userRepository: UserRepository }>;
+export const addRepositories = (c: IDIContainer<{ db: Db }>): DIWithRepositories =>
+  c.add('userRepository', ({ db }) => new UserRepository(db));
+```
+
+If the full boilerplate is too much, a `SealedContainer` boundary every few modules gets most of the
+benefit.
+
 ### Naming the container type
 
 `typeof container` and `ReturnType<typeof configureDI>` both expand in diagnostics, so a large
@@ -231,16 +296,19 @@ resolved _before_ it keeps the old instance it was constructed with.
 
 ## Decoding errors
 
-| Symptom                                                                 | Cause                                     | Fix                                         |
-| ----------------------------------------------------------------------- | ----------------------------------------- | ------------------------------------------- |
-| `Argument of type '"x"' is not assignable to parameter of type 'never'` | Name already registered, or not a literal | Use `update`, or make the name a literal    |
-| `Property 'x' does not exist on type 'IDIContainer<…>'`                 | Not registered, or module not composed in | Register it, or add its module to `compose` |
-| `Argument of type '{…}' is not assignable to … 'Factory<…>'`            | Passed a value instead of a factory       | Wrap it: `() => value`                      |
-| `ForbiddenNameError`                                                    | Used a reserved method name               | Rename the dependency                       |
-| `DenyOverrideDependencyError`                                           | `add` on an existing name                 | Use `update`                                |
-| `DependencyIsMissingError`                                              | `get`/`update` on an unknown name         | Register it first                           |
-| `TypeError: resolver is not a function`                                 | Registered a value, not a factory         | Wrap it: `() => value`                      |
-| Editor sluggish in the container file                                   | One long `.add()` chain (O(N²))           | Split into modules and `compose`            |
+| Symptom                                                                 | Cause                                                        | Fix                                                                                         |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| `Argument of type '"x"' is not assignable to parameter of type 'never'` | Name already registered, or not a literal                    | Use `update`, or make the name a literal                                                    |
+| `Property 'x' does not exist on type 'IDIContainer<…>'`                 | Not registered, or module not composed in                    | Register it, or add its module to `compose`                                                 |
+| `Argument of type '{…}' is not assignable to … 'Factory<…>'`            | Passed a value instead of a factory                          | Wrap it: `() => value`                                                                      |
+| `ForbiddenNameError`                                                    | Used a reserved method name                                  | Rename the dependency                                                                       |
+| `DenyOverrideDependencyError`                                           | `add` on an existing name                                    | Use `update`                                                                                |
+| `DependencyIsMissingError`                                              | `get`/`update` on an unknown name                            | Register it first                                                                           |
+| `TypeError: resolver is not a function`                                 | Registered a value, not a factory                            | Wrap it: `() => value`                                                                      |
+| Editor sluggish in the container file                                   | One long `.add()` chain (O(N²))                              | Split into modules and `compose`                                                            |
+| `TS2589: Type instantiation is excessively deep`                        | Depth accumulated across a long chain                        | Give modules explicit named return types; stop chaining `ReturnType<typeof previousModule>` |
+| Every `add` name reports `parameter of type 'never'`                    | The container type collapsed, usually the same depth problem | Same fix — check the module boundaries first                                                |
+| Splitting into modules didn't speed anything up                         | Modules thread the whole accumulated type                    | Give each a declared consumed-type seed and `compose`                                       |
 
 ---
 
@@ -250,6 +318,9 @@ resolved _before_ it keeps the old instance it was constructed with.
 - [ ] No dependency uses a reserved name.
 - [ ] Async resources are awaited before the container is built.
 - [ ] More than ~40 dependencies → split into modules and `compose`.
+- [ ] Each module declares the dependencies it consumes as an explicit interface — not
+      `Pick<FullContainer, …>`, and not by inferring from the previous module with `ReturnType`.
+- [ ] Long `.extend()` chains give each module an explicit named return type.
 - [ ] The container is resolved at the composition root, not passed through the app.
 - [ ] `add` used for new names, `update` only for deliberate replacement.
 - [ ] The project type-checks (`tsc --noEmit`) — RSDI's guarantees are compile-time.

--- a/docs/ai-agent-guide.md
+++ b/docs/ai-agent-guide.md
@@ -1,0 +1,255 @@
+# Integrating RSDI — guide for AI agents
+
+> **Audience:** AI coding agents wiring RSDI into an application. Humans are welcome, but this is
+> written to be read start-to-finish by a model before writing container code.
+>
+> For contributing to RSDI itself, see `AGENTS.md` in the repository root instead.
+
+RSDI is a dependency injection container with no decorators and no `reflect-metadata`. Dependencies
+are registered as factory functions and resolved lazily; the container's _type_ is the map of
+everything registered, so `container.userService` is typed as `UserService` and a typo is a compile
+error.
+
+---
+
+## Quick reference
+
+```ts
+import { DIContainer, type IDIContainer, type SealedContainer } from 'rsdi';
+
+const container = new DIContainer()
+  .add('config', () => loadConfig())
+  .add('db', ({ config }) => new Db(config.dbUrl))
+  .add('userRepository', ({ db }) => new UserRepository(db));
+
+container.userRepository; // UserRepository — resolved on first access, then cached
+container.get('userRepository'); // identical
+```
+
+| Call                           | Returns                     | Notes                                                        |
+| ------------------------------ | --------------------------- | ------------------------------------------------------------ |
+| `new DIContainer()`            | empty container             | Constructor takes **no** arguments                           |
+| `.add(name, factory)`          | container + that name       | **Throws** if `name` already exists                          |
+| `.get(name)`                   | the dependency              | Same as property access; throws if not registered            |
+| `.update(name, factory)`       | container, name retyped     | **Throws** if `name` does not exist; evicts the cached value |
+| `.has(name)`                   | `boolean`                   | Is a resolver registered?                                    |
+| `.hasResolvedDependency(name)` | `boolean`                   | Has it been _resolved_ yet?                                  |
+| `.merge(...containers)`        | **mutated** `this`          | Later containers win on duplicate names                      |
+| `DIContainer.compose(...cs)`   | a **new** container         | Static; inputs untouched                                     |
+| `.clone()`                     | a new, independent instance | Copies resolvers and already-resolved values                 |
+| `.extend(fn)`                  | whatever `fn` returns       | For layered modules that need earlier types                  |
+
+Install: `npm install rsdi` (or `pnpm add rsdi`). The package is **ESM-only**; `engines.node` is
+`>=16.9.0`. A CommonJS project needs Node 20.19+/22.12+ to `require()` it, and TypeScript consumers
+need `"module": "nodenext"` — on `Node16` you get `TS1479`.
+
+---
+
+## Rules that will bite you
+
+These are the mistakes worth checking for explicitly. Each one is real: they either fail to compile
+or fail at runtime.
+
+### 1. The second argument is a **function**, always
+
+```ts
+const connection = await createConnection();
+
+container.add('db', connection); // ✗ TS2345, and at runtime: "resolver is not a function"
+container.add('db', () => connection); // ✓
+```
+
+Registering a value directly is the single most common mistake. `add` stores the argument as a
+resolver and calls it on first access.
+
+### 2. Names must be inline string literals
+
+The duplicate-name guard works on literal types, so a widened `string` resolves to `never`:
+
+```ts
+const name = 'db';
+container.add(name, () => new Db()); // ✓ `const` keeps the literal type
+
+let key = 'db';
+container.add(key, () => new Db()); // ✗ `key` is `string` → parameter type is `never`
+```
+
+If you need dynamic registration, you are outside what the types can express — reconsider the design
+rather than casting.
+
+### 3. These names are reserved
+
+`add`, `clone`, `extend`, `get`, `has`, `hasResolvedDependency`, `merge`, `update`.
+
+A dependency named after a container method would shadow it, so it throws `ForbiddenNameError` at
+runtime and is rejected at compile time. `compose` is _not_ reserved — it is a static method, so it
+never collides with an instance property.
+
+### 4. `add` refuses to overwrite; `update` requires an existing name
+
+```ts
+container.add('db', () => new Db()); // second time: DenyOverrideDependencyError
+container.update('db', () => new FakeDb()); // ✓ replaces, and evicts the cached instance
+container.update('nope', () => 1); // DependencyIsMissingError
+```
+
+This is deliberate — accidental redefinition is a common DI bug. Use `update` only when you mean it
+(mostly test mocking).
+
+### 5. `merge` mutates, `compose` does not
+
+```ts
+base.merge(repositories, services); // mutates and returns `base`
+DIContainer.compose(repositories, services); // new container; inputs untouched
+base.clone(); // independent copy
+```
+
+If you need the original container left alone, use `compose` or `clone`.
+
+### 6. No async factories
+
+Factories are synchronous. Resolve async resources _before_ building the container:
+
+```ts
+const connection = await createConnection(); // await first
+const container = new DIContainer().add('db', () => connection);
+```
+
+See [async factory resolvers](https://github.com/radzserg/rsdi3/blob/main/docs/async_factory_resolver.md)
+for the reasoning.
+
+### 7. Don't pass the container through your application
+
+Resolve at the composition root (entry point, router setup) and hand components their dependencies.
+Threading the container into business logic recreates the coupling DI is meant to remove — see
+[DI container vs context](https://github.com/radzserg/rsdi3/blob/main/docs/context_vs_container.md).
+
+---
+
+## Wiring a real application
+
+**Split the graph into module files and combine them.** This is the recommended layout, and past a
+few dozen dependencies it is not optional — a single `.add()` chain costs **O(N²)** to type-check.
+Measured on TypeScript 7: 1600 dependencies in one chain takes **90 seconds** to check; the same
+graph as 80 modules combined with `compose` takes **0.9 seconds**. Aim for **20–40 dependencies per
+module**.
+
+```ts
+// di/repositories.ts
+import { DIContainer } from 'rsdi';
+
+export const repositories = new DIContainer()
+  .add('userRepository', () => new UserRepository())
+  .add('orderRepository', () => new OrderRepository());
+```
+
+```ts
+// di/services.ts — declares what it expects the composed container to provide
+import { DIContainer } from 'rsdi';
+
+export const services = new DIContainer<{ userRepository: UserRepository }>()
+  .add('mailer', () => new Mailer())
+  .add('userService', ({ userRepository }) => new UserService(userRepository));
+```
+
+```ts
+// di/index.ts
+import { DIContainer, type SealedContainer } from 'rsdi';
+import { repositories } from './repositories.js';
+import { services } from './services.js';
+
+export const container = DIContainer.compose(repositories, services);
+export type AppContainer = SealedContainer<typeof container>;
+```
+
+Resolution happens lazily against the **composed** container, so `userService` resolves
+`userRepository` from the other module at runtime. Only the _types_ of a module are limited to what
+that module declares — hence the `new DIContainer<{ userRepository: UserRepository }>()` annotation
+above.
+
+### Choosing how to combine modules
+
+| Situation                                                  | Use                                    |
+| ---------------------------------------------------------- | -------------------------------------- |
+| Modules are independent, or declare their own requirements | `DIContainer.compose(a, b, c)`         |
+| A module needs earlier modules' types while you write it   | `.extend(fn)`                          |
+| You already have a base container to fold others into      | `base.merge(a, b, c)` (mutates `base`) |
+
+`extend` passes the accumulated container to a function, so the next module sees real types without
+annotating anything:
+
+```ts
+// di/validators.ts
+import { type IDIContainer } from 'rsdi';
+
+export const addValidators = (container: IDIContainer<{ userRepository: UserRepository }>) =>
+  container.add('userValidator', ({ userRepository }) => new UserValidator(userRepository));
+```
+
+```ts
+export const container = DIContainer.compose(repositories).extend(addValidators);
+```
+
+Both patterns scale — measured at 800 dependencies, `compose` and `extend` are within the same order
+of magnitude of each other and ~10× cheaper than one flat chain.
+
+### Naming the container type
+
+`typeof container` and `ReturnType<typeof configureDI>` both expand in diagnostics, so a large
+container produces errors like `IDIContainer<{ a: string; } & { b: number; } & …>`. Wrapping in
+`SealedContainer` gives TypeScript a name to print instead:
+
+```ts
+export type AppContainer = SealedContainer<typeof container>;
+
+export function configureRouter(app: Express, container: AppContainer) {
+  const { userController } = container; // still exactly typed
+}
+```
+
+This is for readability only — it does not speed anything up. Referring to a container from another
+file is already cheap.
+
+---
+
+## Testing
+
+Build the real container, then `update` the pieces you want to fake. Use `clone` when a test must not
+affect others:
+
+```ts
+const container = configureDI().clone();
+container.update('userRepository', () => new InMemoryUserRepository());
+
+expect(container.userService.register(data)).resolves.toBeDefined();
+```
+
+`update` evicts any cached instance, so dependencies resolved after it see the replacement. Anything
+resolved _before_ it keeps the old instance it was constructed with.
+
+---
+
+## Decoding errors
+
+| Symptom                                                                 | Cause                                     | Fix                                         |
+| ----------------------------------------------------------------------- | ----------------------------------------- | ------------------------------------------- |
+| `Argument of type '"x"' is not assignable to parameter of type 'never'` | Name already registered, or not a literal | Use `update`, or make the name a literal    |
+| `Property 'x' does not exist on type 'IDIContainer<…>'`                 | Not registered, or module not composed in | Register it, or add its module to `compose` |
+| `Argument of type '{…}' is not assignable to … 'Factory<…>'`            | Passed a value instead of a factory       | Wrap it: `() => value`                      |
+| `ForbiddenNameError`                                                    | Used a reserved method name               | Rename the dependency                       |
+| `DenyOverrideDependencyError`                                           | `add` on an existing name                 | Use `update`                                |
+| `DependencyIsMissingError`                                              | `get`/`update` on an unknown name         | Register it first                           |
+| `TypeError: resolver is not a function`                                 | Registered a value, not a factory         | Wrap it: `() => value`                      |
+| Editor sluggish in the container file                                   | One long `.add()` chain (O(N²))           | Split into modules and `compose`            |
+
+---
+
+## Checklist before finishing
+
+- [ ] Every `add`/`update` second argument is a function.
+- [ ] No dependency uses a reserved name.
+- [ ] Async resources are awaited before the container is built.
+- [ ] More than ~40 dependencies → split into modules and `compose`.
+- [ ] The container is resolved at the composition root, not passed through the app.
+- [ ] `add` used for new names, `update` only for deliberate replacement.
+- [ ] The project type-checks (`tsc --noEmit`) — RSDI's guarantees are compile-time.

--- a/docs/async_factory_resolver.md
+++ b/docs/async_factory_resolver.md
@@ -25,9 +25,14 @@ async function configureDI() {
   // initialize async factories before DI container initialisation
   const dbConnection = await createConnections();
 
-  return new DIContainer()
-    .add('dbConnection', dbConnection)
-    .add('userRepository', ({ dbConnection }) => new UserRepository(dbConnection));
+  return (
+    new DIContainer()
+      // note the arrow function: `add` takes a factory, never a value. Passing
+      // `dbConnection` directly fails to compile and throws "resolver is not a
+      // function" at runtime.
+      .add('dbConnection', () => dbConnection)
+      .add('userRepository', ({ dbConnection }) => new UserRepository(dbConnection))
+  );
 }
 
 // main.ts

--- a/docs/type-benchmarks.md
+++ b/docs/type-benchmarks.md
@@ -1,0 +1,132 @@
+# Reading `pnpm bench:types`
+
+> **Audience:** contributors and AI agents changing `src/types.ts` or an
+> `add`/`merge`/`compose` signature. The gate lives in `scripts/bench-types.mjs` and runs in CI as
+> the `types-perf` job. For the measurements behind it, see
+> [type-performance-plan.md](./type-performance-plan.md).
+
+Per-key inference is the whole product here, and the machinery producing it is quadratic by
+construction — each `add` re-embeds the growing resolver map. That makes it easy to add a
+small-looking type and multiply everyone's build time. This gate measures that cost.
+
+---
+
+## The report
+
+```
+types-bench: TypeScript Version 7.0.2      ← budgets are tied to this version
+✓ chain-200 — 267,699 / 330,000 instantiations (81% of budget)
+│  │           │         │                      └ how much headroom is left
+│  │           │         └ the ceiling, ~25% above what it measured when set
+│  │           └ what this run actually cost
+│  └ scenario name
+└ pass/fail
+    flat chain of 200 add() calls          ← the shape being measured
+```
+
+The **percentage** is the part to watch. Below ~85% is healthy. Between 85% and 100% it still
+passes, but the headroom is nearly gone — understand why your change moved it before merging.
+Above 100% it fails.
+
+### What each scenario guards
+
+| Scenario        | Catches                                                                         |
+| --------------- | ------------------------------------------------------------------------------- |
+| `chain-200`     | the per-`add` cost — what every user pays on every dependency                   |
+| `compose-400`   | the `compose` path specifically                                                 |
+| `compose-scale` | the depth limiter at 60 containers — the trap that produces no error when small |
+
+---
+
+## The two ways it fails
+
+They mean different things, and only one of them is ever fixed by editing the budget.
+
+**Budget exceeded.** Your change made the types more expensive per dependency:
+
+```
+✗ chain-200 — flat chain of 200 add() calls
+  267,699 instantiations exceeds the 200,000 budget (134%).
+```
+
+Decide whether the increase is justified. If it is, raise the budget in `scripts/bench-types.mjs`
+and say why in the commit. If it is not, the type you added is doing per-dependency work that
+something cheaper could do.
+
+**Inference broke.** A diagnostic appeared, which is a correctness bug, not a slow one:
+
+```
+✗ compose-scale — 60 composed containers (depth-limiter guard)
+  inference broke: 10 diagnostic(s)
+    error TS2589: Type instantiation is excessively deep and possibly infinite.
+    error TS2339: Property 'num0' does not exist on type 'never'.
+```
+
+`TS2589` means a type started recursing per dependency; `… does not exist on type 'never'` means
+inference collapsed entirely. **Never raise a budget to silence this.** Both known causes are
+recorded in [type-performance-plan.md](./type-performance-plan.md#what-does-not-help-ruled-out--dont-re-attempt):
+a recursive tuple fold in `MergedResolvers`, and a `Simplify`-style flatten on the `add`
+accumulator. Both look perfectly fine at three dependencies — that is exactly why this gate exists,
+and both pass the full 82-test suite untouched.
+
+---
+
+## Why instantiations, not time
+
+A **type instantiation** is one act of the checker producing a concrete type from a generic by
+substituting type arguments — `IDIContainer<{ a: string }>` out of `IDIContainer<CR>`. It is the
+unit of work the type system does, and it is what this library spends. Link _k_ of a chain costs
+O(_k_) instantiations, so N dependencies cost O(N²).
+
+The practical reason is that **it is deterministic and time is not**. The same file, same compiler,
+five consecutive runs:
+
+| Run | Instantiations | Check time |
+| --- | -------------: | ---------: |
+| 1   |        266,808 |     0.287s |
+| 2   |        266,808 |     0.282s |
+| 3   |        266,808 |     0.266s |
+| 4   |        266,808 |     0.284s |
+| 5   |        266,808 |     0.327s |
+
+Identical every time, while wall clock swings ~11% from CPU scheduling, thermal state and cache. A
+gate on time would either flake or need thresholds so loose they catch nothing. Three consequences:
+
+- **Budgets are machine-independent.** A number set on a laptop holds on any CI runner.
+- **A regression is unambiguous.** If the count moved, your change moved it.
+- **It is sensitive to structure.** The quadratic shows up as instantiations quadrupling per
+  doubling (74K → 264K → 1.00M → 3.92M) long before anyone notices a slow build.
+
+Time is still what users feel — that is why the plan quotes 90.2s → 0.9s at 1600 dependencies. It is
+just the wrong thing to _gate_ on.
+
+---
+
+## Two caveats
+
+**Lower is not automatically better.** A change degrading every dependency to `any` would slash the
+count while destroying the point of the library. Every fixture therefore also asserts exact types
+with a compile-time `Exact<>` check, so the gate cannot be satisfied by making inference worse.
+Treat an unexplained _drop_ as suspicious, not as a win.
+
+**The number is a proxy, and it is compiler-specific.** It counts instantiations, not every kind of
+checker work — expensive assignability comparisons or very large unions can hurt without moving it
+much. And a TypeScript upgrade shifts every number, so budgets must be re-baselined in the same
+commit as the bump: run the script, read the reported actuals, update `BUDGETS`. This is not
+hypothetical — the TS 6 → 7 move changed the figures here and invalidated one earlier finding
+outright.
+
+---
+
+## Measuring something else
+
+To profile a shape the gate does not cover, compile it directly. Use `./node_modules/.bin/tsc`
+rather than `npx tsc`, which resolves to an unrelated placeholder package:
+
+```bash
+./node_modules/.bin/tsc --noEmit --ignoreConfig --extendedDiagnostics --strict --skipLibCheck \
+  --target es2022 --lib es2022 --module nodenext --moduleResolution nodenext yourfile.ts
+```
+
+Read `Instantiations:`, ignore `Check time:`. If the shape is worth protecting, add it as a scenario
+in `scripts/bench-types.mjs` instead of keeping a one-off script.

--- a/docs/type-performance-plan.md
+++ b/docs/type-performance-plan.md
@@ -171,6 +171,13 @@ constraint) only pay off when factories **don't** read their deps; real factorie
   at ~50 containers**, inference degrades silently. This is why `MergedResolvers` uses a
   union-to-intersection fold instead, which gets _cheaper_ as the container count grows
   (163K → 114K instantiations going from 50 to 200 containers).
+- **Last-writer-wins _types_ for duplicate names across composed containers.** Runtime is
+  last-wins, but the types intersect, so the same name registered with two different types
+  resolves to `never`. Making the types match the runtime needs an order-preserving fold
+  (`Omit<Fold<Rest>, keyof Last> & Last`), which is recursive per container and — measured —
+  trips **TS2589 at 50 containers**, exactly the ceiling `compose` exists to clear. Identical
+  types on both sides are unaffected. Kept as-is and documented: `never` surfaces a duplicate
+  name instead of silently picking one, and deliberate replacement has `update()`.
 - **Removing methods** (`get/update/merge/extend/clone/has`) or the **`CR &` property-access
   sugar**: ≈0% change. They're only instantiated on the final type, not per step. The cost
   is `add` alone.

--- a/docs/type-performance-plan.md
+++ b/docs/type-performance-plan.md
@@ -2,62 +2,68 @@
 
 > **Audience:** AI agents and maintainers continuing work on the "heavy types" pain point.
 > **Context:** In large projects (hundreds–thousands of dependencies) the container's
-> types get expensive to check and, past a threshold, crash `tsc` outright. This doc
-> captures the root-cause analysis, the measured evidence, what does **not** help, and
-> the ranked improvement plan with status.
+> types get expensive to check. This doc captures the root-cause analysis, the measured
+> evidence, what does **not** help, and the ranked improvement plan with status.
 
-All numbers below were measured with the repo's own **TypeScript 6.0.3** under `strict`,
-via `tsc --extendedDiagnostics`. **Instantiation counts are deterministic** and are the
-reliable metric; wall-clock check-time is single-run noise (±0.15s) — treat it as indicative only.
+Numbers are measured under `strict` via `tsc --extendedDiagnostics`. **Instantiation counts
+are deterministic** and are the reliable metric; wall-clock check-time is single-run noise —
+treat it as indicative only.
+
+The repo moved from **TypeScript 6.0.3** to **TypeScript 7.0.2** (the native Go compiler)
+partway through this work. Everything below was **re-measured on TS 7**; where TS 7 changed
+a conclusion it is called out explicitly. Re-validate after any future compiler bump —
+one finding (the crash) did not survive the last one.
 
 ---
 
 ## TL;DR
 
 - Each `.add()` returns `IDIContainer<CR & { [n in N]: … }>`. The container type **is** the
-  full dependency map, re-embedded at every link. Type-checking link *k* is **O(k)**, so a
+  full dependency map, re-embedded at every link. Type-checking link _k_ is **O(k)**, so a
   chain of N adds is **O(N²)**. This is inherent to any fluent builder that exposes exact
-  per-key types — not a bug in the type code.
-- **Two cliffs:** (1) O(N²) makes big projects slow to check; (2) a **single fluent
-  `.add().add()…` expression of ~500–600 links crashes `tsc`** with
-  `RangeError: Maximum call stack size exceeded` — this is **AST depth**, independent of
-  the type design (even a minimal container type crashes at the same length).
-- **The real fix for "thousands" is composition** (split into modules, `merge`/`extend`):
-  it turns O(N²) into ~O(N²/m + N) and keeps every chain short. Everything else is
-  constant-factor cleanup or guardrails.
+  per-key types — not a bug in the type code. **Still true on TS 7.**
+- **The fix for "thousands" is composition** (build modules independently, then combine):
+  it turns O(N²) into ~O(N²/m + N) and keeps every chain short. At 1600 dependencies this is
+  **~22× fewer instantiations and ~100× faster** (90.2 s → 0.9 s). Shipped as
+  `DIContainer.compose()` + variadic `merge()`.
+- **Fixed on TS 7:** under TS 6, one fluent `.add().add()…` expression of ~500–600 links
+  crashed `tsc` with `RangeError: Maximum call stack size exceeded` (AST depth, not types).
+  The Go compiler handles 1200+ links without crashing — just slowly. Item 2 is therefore
+  moot for TS 7 consumers and remains relevant only for anyone still on TS 6.
 
 ---
 
 ## Status of the plan
 
-| # | Item | Impact | Risk | Status |
-|---|------|--------|------|--------|
-| 1 | Make modular composition first-class (`compose`/`register` helper + docs) | **High** (the scalability answer) | Low–Med | ⬜ Not started |
-| 2 | Guardrail the single-chain crash (array-based API + docs) | Med (prevents hard failure) | Low | ⬜ Not started |
-| 3 | Constant-factor type cleanups (`add`/`update` signatures) | Low–Med | Low | ✅ **Done** |
-| 4 | Escape hatch for consumers (seal container behind a named type) | Med (downstream files) | Low | ⬜ Not started |
-| 5 | CI perf regression gate (benchmark harness) | Med (prevents regressions) | Low | ⬜ Not started |
+| #   | Item                                                                       | Impact                            | Risk    | Status                                               |
+| --- | -------------------------------------------------------------------------- | --------------------------------- | ------- | ---------------------------------------------------- |
+| 1   | Make modular composition first-class (`compose` + variadic `merge` + docs) | **High** (the scalability answer) | Low–Med | ✅ **Done**                                          |
+| 2   | Guardrail the single-chain crash                                           | —                                 | —       | ➖ **Obsolete on TS 7** (no crash); item 1 covers it |
+| 3   | Constant-factor type cleanups (`add`/`update` signatures)                  | Low–Med                           | Low     | ✅ **Done**                                          |
+| 4   | Escape hatch for consumers (seal container behind a named type)            | Med (downstream files)            | Low     | ⬜ Not started                                       |
+| 5   | CI perf regression gate (benchmark harness)                                | Med (prevents regressions)        | Low     | ⬜ Not started                                       |
 
 ---
 
 ## Root cause
 
 `IDIContainer<CR> = CR & { add; get; update; merge; extend; clone; has; … }`, and
-`add` returns `IDIContainer<CR & { [n in N]: V }>`. To type-check link *k* against a
-*k*-key map, TypeScript must:
+`add` returns `IDIContainer<CR & { [n in N]: V }>`. To type-check link _k_ against a
+_k_-key map, TypeScript must:
 
-1. resolve `.add` on a *k*-constituent intersection (`CR & { …methods }`);
+1. resolve `.add` on a _k_-constituent intersection (`CR & { …methods }`);
 2. compute `keyof CR` for the `DenyInputKeys` duplicate-name guard;
 3. relate the factory to `(resolvers: CR) => V` and resolve any destructured deps
-   (`({ a, b }) =>`) against the *k*-key map;
+   (`({ a, b }) =>`) against the _k_-key map;
 4. build the next `CR & { new }` and re-instantiate the **recursive** `IDIContainer` alias.
 
 Each is **O(k)** ⇒ whole chain **O(N²)**.
 
-The ~500–600-link **crash** is a separate mechanism: one `.add().add()…` mega-expression
-is a 500+-deep syntax tree, and `tsc`'s parent-node walkers (e.g. `getAssignmentDeclarationKind`)
-overflow the JS call stack. Splitting the identical adds into separate statements removes
-the crash (but stays O(N²)).
+**The TS 6 crash (historical).** One `.add().add()…` mega-expression is a 500+-deep syntax
+tree, and TS 6's parent-node walkers (e.g. `getAssignmentDeclarationKind`) overflowed the JS
+call stack at ~500–600 links; splitting the adds into separate statements removed it. TS 7's
+Go compiler does not have this limit (verified to 1200 links), so this no longer gates anyone
+on a current toolchain.
 
 ---
 
@@ -67,39 +73,50 @@ Faithfulness check: an inlined model of `types.ts` reproduced the **real** `src/
 cost to within ~1.5% (266,569 vs 262,853 instantiations at N=200), so the model-based
 ablations below are trustworthy.
 
-### Single fluent chain scales quadratically, then crashes
+### Single fluent chain scales quadratically (TS 7, real `src/`, factories reading deps)
 
-| Scenario (TS 6.0.3, strict) | Instantiations | Check time | Result |
-|---|---:|---:|---|
-| chain N=100 | 71K | 0.20s | ok |
-| chain N=200 (real `src/`) | 266K | 0.81s | ok |
-| chain N=400 | 674K–1.02M | 3.9–4.2s | slow |
-| **chain N≈600** | — | — | **`RangeError: Maximum call stack size exceeded`** |
+| Scenario | Instantiations | Check time |
+| -------- | -------------: | ---------: |
+| N=100    |            74K |      0.06s |
+| N=200    |           264K |      0.26s |
+| N=400    |          1.00M |      1.63s |
+| N=800    |          3.92M |      11.9s |
 
-Crash threshold is between **500 (ok)** and **600 (crash)** links. Confirmed design-independent
-(a bare minimal container type crashes at 600 too). Same 800 adds as **separate statements**
-do **not** crash (they compile in ~30s / ~3.9M instantiations).
+Instantiations quadruple per doubling — textbook O(N²). No crash at any length on TS 7
+(a single 1200-link expression compiles in ~37s).
 
-### Composition breaks the quadratic (N=400, current types)
+### Composition breaks the quadratic (TS 7, real `DIContainer.compose`)
 
-| Layout | Instantiations | Check time |
-|---|---:|---:|
-| 1 × 400 (one chain) | 674K | 3.85s |
-| 4 × 100 | 196K | 0.52s |
-| 8 × 50 | 117K | 0.31s |
-| **20 × 20** | **74K** | **0.28s** |
+| Layout                        | Instantiations | Check time |
+| ----------------------------- | -------------: | ---------: |
+| 1 chain of 400                |           519K |      1.50s |
+| 20 modules × 20 → compose     |            97K |      0.09s |
+| 1 chain of 800                |          1.99M |      11.5s |
+| 40 modules × 20 → compose     |           185K |      0.26s |
+| **1 chain of 1600**           |  **7,815,223** |  **90.2s** |
+| **80 modules × 20 → compose** |    **361,552** |   **0.9s** |
 
-≈9× fewer instantiations, ≈14× faster — **and** every module chain stays short (fast editor
-feedback, no crash risk).
+At 1600 dependencies that is **~22× fewer instantiations and ~100× faster**. The win grows
+with N, because the flat chain is quadratic and the composed layout is not.
+
+Module _size_ matters more than module count: 20–40 dependencies per module is the sweet
+spot, and past that the returns flatten (m=40 vs m=80 at N=1600 differ by <25%).
+
+### The `extend` pattern scales too (and keeps cross-module types)
+
+Module functions with an explicitly declared requirement, folded with `.extend()`:
+N=800 as 20 modules costs **187K / 0.19s** — same order as `compose`, versus 1.99M / 11.5s
+for the flat chain. Use `extend` when a module needs a previous module's types while it is
+being written; use `compose` for independently built modules.
 
 ### Cost decomposition (per-`add`, N=400, no-deref)
 
-| Variant | Instantiations | vs full |
-|---|---:|---:|
-| full `add` (guard + `Factory<CR>` constraint) | 674K | — |
-| drop `keyof` duplicate-guard | 496K | −26% |
-| drop `Factory<CR>` constraint | 350K | −48% |
-| drop both ("bare") | 172K | −75% (still O(N²)) |
+| Variant                                       | Instantiations |            vs full |
+| --------------------------------------------- | -------------: | -----------------: |
+| full `add` (guard + `Factory<CR>` constraint) |           674K |                  — |
+| drop `keyof` duplicate-guard                  |           496K |               −26% |
+| drop `Factory<CR>` constraint                 |           350K |               −48% |
+| drop both ("bare")                            |           172K | −75% (still O(N²)) |
 
 Even the bare minimum is quadratic. The two removable hotspots (`keyof` guard, `Factory`
 constraint) only pay off when factories **don't** read their deps; real factories destructure
@@ -112,6 +129,11 @@ constraint) only pay off when factories **don't** read their deps; real factorie
 - **Naive `Simplify`/`Prettify` flatten** on the accumulator (`{ [K in keyof T]: T[K] }`):
   trips TS's depth limiter (**TS2589**) at ~50 links and silently collapses inference to
   `never`. Actively harmful.
+- **A recursive tuple fold for combining containers**
+  (`T extends [infer H, ...infer R] ? ResolversOf<H> & Fold<R> : {}`): same failure — **TS2589
+  at ~50 containers**, inference degrades silently. This is why `MergedResolvers` uses a
+  union-to-intersection fold instead, which gets _cheaper_ as the container count grows
+  (163K → 114K instantiations going from 50 to 200 containers).
 - **Removing methods** (`get/update/merge/extend/clone/has`) or the **`CR &` property-access
   sugar**: ≈0% change. They're only instantiated on the final type, not per step. The cost
   is `add` alone.
@@ -122,23 +144,46 @@ constraint) only pay off when factories **don't** read their deps; real factorie
 
 ## The plan
 
-### 1. Make modular composition first-class — *the actual fix for "thousands"* ⬜
+### 1. Make modular composition first-class — _the actual fix for "thousands"_ ✅ **Done**
 
-Splitting N deps into *m* modules and combining cuts build cost ~*m*× (O(N²)→O(N²/m + N))
-and keeps each chain short. `merge`/`extend` already exist; the work is ergonomics + docs:
+Shipped two additions, both driven by the same type helper:
 
-- Add a composition helper so users never write one giant chain — e.g.
-  `DIContainer.compose(moduleA, moduleB, …)` or `container.register(fnA, fnB, …)` folding
-  `extend`. A **rest/array-argument** form is important: it also sidesteps the AST-depth crash.
-- Prominent README/docs guidance: "for large graphs, split into feature modules and
-  `merge`/`extend`."
-- Verify the helper's own type cost stays ~linear in module count (the 20×20 data suggests it does).
+- **`DIContainer.compose(...containers)`** — a **static** method that combines independently
+  built containers into a **new** container (inputs untouched). This is the documented way to
+  wire a large graph.
+- **Variadic `merge(...containers)`** — the existing instance method now takes any number of
+  containers, so `base.merge(repos, services, controllers)` replaces a chain of merges.
+  Backward compatible: single-argument calls infer exactly as before.
 
-### 2. Guardrail the single-chain crash ⬜
+Type machinery in `types.ts`: `ContainerLike`, `ResolversOf`, `UnionToIntersection`, and
+`MergedResolvers` (union-to-intersection, **not** a recursive fold — see the ruled-out list).
+`ResolversOf` checks the `DIContainer` class branch **before** the `IDIContainer` branch,
+because a class instance also structurally matches `IDIContainer`; without that ordering a raw
+`new DIContainer()` passed to `compose` silently contributes `never`.
 
-Even after everything else, ~500+ links in one expression stack-overflow `tsc`. Document a
-soft cap ("keep any single `.add()` chain to a few hundred; beyond that, compose") and prefer
-the array-based `register([...])` API from item 1, which avoids the giant-expression AST entirely.
+`compose` is **static**, so it needs no entry in the `containerMethods` guard set — that set
+only protects instance members from being shadowed by dependency names.
+
+- **Verified:** exact inference on composed containers, composed containers stay chainable,
+  zero-argument and single-argument `compose`, raw `DIContainer` instances accepted, modules
+  that declare their requirements (`new DIContainer<{ bar: Bar }>()`) compose correctly.
+  Runtime: laziness/caching preserved, resolved values carried over, inputs not mutated,
+  cross-module dependencies resolve, last-writer-wins on duplicate names.
+- Full gate green: `pnpm build`, `pnpm test` (59 tests + type tests), `pnpm lint`.
+- Measured: see the composition table above (1600 deps: 90.2s → 0.9s).
+
+**Known limitation (documented in the README).** A module built standalone only _types_ what
+it declares, so a factory in module B cannot destructure module A's dependencies with
+inference unless the module annotates its requirement
+(`new DIContainer<{ userRepository: UserRepository }>()`) or is layered with `.extend()`
+instead. Resolution itself is unaffected — it happens lazily against the composed container.
+
+### 2. Guardrail the single-chain crash ➖ **Obsolete on TS 7**
+
+Under TS 6, ~500+ links in one expression stack-overflowed `tsc`. TS 7's Go compiler has no
+such limit (verified to 1200 links), so no guardrail is needed on a current toolchain. Item 1
+addresses the remaining (performance) reason to avoid very long chains. Revisit only if the
+project ever supports TS 6 consumers again.
 
 ### 3. Constant-factor type cleanups ✅ **Done**
 
@@ -150,13 +195,13 @@ declared return type unchanged). Two fewer moving parts per call site; one gener
 
 - **Verified:** exact inference preserved (literal widening `() => 123` → `number`, `update`
   override, factories reading prior deps, duplicate-name / unknown-dep still error).
-- Full gate green: `pnpm build`, `pnpm test` (42 tests + type tests), `npx eslint`.
-- Measured: N=200 deref 266,569 → 263,808 (−1%); no-deref ~177K → 140,255 (−20%).
+- Full gate green: `pnpm build`, `pnpm test` (42 tests + type tests), lint.
+- Measured (TS 6): N=200 deref 266,569 → 263,808 (−1%); no-deref ~177K → 140,255 (−20%).
 
 ### 4. Escape hatch for downstream consumers ⬜
 
 Document sealing the built container behind a single named type —
-`export type AppContainer = ReturnType<typeof buildContainer>` — so files that *consume* the
+`export type AppContainer = ReturnType<typeof buildContainer>` — so files that _consume_ the
 container reference one materialized type instead of re-deriving the whole builder chain.
 Optionally offer an opt-in loose/index-signature mode for extreme scale.
 
@@ -187,17 +232,21 @@ for (let i = 2; i < n; i++)
 writeFileSync(`chain_${n}.ts`, s);
 ```
 
-Use **per-statement** form (as above) to measure type cost without the AST-depth crash;
-use one `.add().add()…` expression to reproduce the crash.
+For the composed layout, emit _m_ independent `new DIContainer()` chains of `N/m` adds each and
+finish with a single `DIContainer.compose(mod0, …, modM)` call.
 
-**Measure** (note TS 6 needs `--ignoreConfig` when a tsconfig is present and files are passed):
+**Measure** — pass `--ignoreConfig` whenever a tsconfig is present and files are listed
+explicitly, and pin `--target/--lib es2022` to match the package's floor:
 
 ```bash
-tsc --noEmit --ignoreConfig --extendedDiagnostics --strict --skipLibCheck \
-  --module nodenext --moduleResolution nodenext chain_200.ts
+./node_modules/.bin/tsc --noEmit --ignoreConfig --extendedDiagnostics --strict --skipLibCheck \
+  --target es2022 --lib es2022 --module nodenext --moduleResolution nodenext chain_200.ts
 # read "Instantiations:" (deterministic) and "Check time:" (noisy)
 ```
 
+Use `./node_modules/.bin/tsc`, not `npx tsc` — `npx` resolves to an unrelated placeholder
+package and prints "This is not the tsc command you are looking for".
+
 Ablation knobs used above: with/without factory dep destructuring ("deref"/"noderef");
-with/without the `keyof` duplicate-guard; with/without the `Factory<CR>` constraint; and
-composition layouts (m modules of N/m combined via `merge`).
+with/without the `keyof` duplicate-guard; with/without the `Factory<CR>` constraint; layout
+(one chain vs _m_ modules); and combinator (`compose`, chained `merge`, `extend` fold).

--- a/docs/type-performance-plan.md
+++ b/docs/type-performance-plan.md
@@ -40,7 +40,7 @@ one finding (the crash) did not survive the last one.
 | 1   | Make modular composition first-class (`compose` + variadic `merge` + docs) | **High** (the scalability answer) | Low–Med | ✅ **Done**                                          |
 | 2   | Guardrail the single-chain crash                                           | —                                 | —       | ➖ **Obsolete on TS 7** (no crash); item 1 covers it |
 | 3   | Constant-factor type cleanups (`add`/`update` signatures)                  | Low–Med                           | Low     | ✅ **Done**                                          |
-| 4   | Escape hatch for consumers (seal container behind a named type)            | Med (downstream files)            | Low     | ⬜ Not started                                       |
+| 4   | Escape hatch for consumers (seal container behind a named type)            | Low (readability only)            | Low     | ✅ **Done** (premise disproved; shipped as DX only)  |
 | 5   | CI perf regression gate (benchmark harness)                                | Med (prevents regressions)        | Low     | ⬜ Not started                                       |
 
 ---
@@ -139,6 +139,9 @@ constraint) only pay off when factories **don't** read their deps; real factorie
   is `add` alone.
 - **Dropping `ReturnType<R>` for an inferred `V`** (item 3): only ~1% once factories read
   their deps. Worth doing for simplicity, not for speed.
+- **Sealing/flattening the container type for consumer files** (item 4): consumers are already
+  cheap (~2.6K instantiations per file, cached per program), and sealing costs ~3% _more_.
+  Useful for readable error messages only — never as a performance fix.
 
 ---
 
@@ -198,12 +201,48 @@ declared return type unchanged). Two fewer moving parts per call site; one gener
 - Full gate green: `pnpm build`, `pnpm test` (42 tests + type tests), lint.
 - Measured (TS 6): N=200 deref 266,569 → 263,808 (−1%); no-deref ~177K → 140,255 (−20%).
 
-### 4. Escape hatch for downstream consumers ⬜
+### 4. Escape hatch for downstream consumers ✅ **Done — but the premise was wrong**
 
-Document sealing the built container behind a single named type —
-`export type AppContainer = ReturnType<typeof buildContainer>` — so files that _consume_ the
-container reference one materialized type instead of re-deriving the whole builder chain.
-Optionally offer an opt-in loose/index-signature mode for extreme scale.
+The item assumed consumer files "re-derive the whole builder chain" and that sealing would cut
+that cost. **Measurement says otherwise, so nothing was shipped as a performance fix.**
+
+Consumer-side cost, N=400 dependencies built from 20 modules:
+
+| Consumers | `typeof container` | sealed (`Simplify` flatten) |
+| --------- | -----------------: | --------------------------: |
+| 1         |               277K |                        284K |
+| 20        |               385K |                        398K |
+| 50        |               409K |                        423K |
+
+Three conclusions, each measured:
+
+1. **Consumers are already cheap.** TypeScript resolves the container type once per program and
+   caches it; going from 1 to 50 consumer files adds only ~2.6K instantiations each. Even 10
+   consumers destructuring 50 dependencies apiece (500 references) changed nothing material.
+2. **Sealing costs more, not less** — consistently ~3% more instantiations, and a
+   `Simplify`-based variant tripled declaration-emit time at N=400 (0.16s → 0.47s). A "faster"
+   helper that is measurably slower would have been actively harmful to ship.
+3. **A loose/index-signature mode is not worth pursuing.** It would trade away exact per-key
+   typing — the entire point of the library — to fix a cost that does not exist.
+
+What _is_ real is **readability**. `typeof container` and `ReturnType<typeof configureDI>` both
+resolve to a type that already carries its own name, so diagnostics expand the full resolver
+intersection — unreadable past a few dozen dependencies. So the shipped piece is a two-line
+ergonomic helper, documented as such:
+
+```ts
+export type SealedContainer<C> = IDIContainer<ResolversOf<C>>;
+```
+
+Wrapping the container creates a _fresh_ alias, so TypeScript prints `AppContainer` instead of
+`IDIContainer<{ a: … } & { b: … } & …>`. The flatten is **not** needed for this —
+`IDIContainer<ResolversOf<C>>` preserves the name on its own, at lower cost than a `Simplify`
+version. `SealedContainer` and `ResolversOf` are now exported from the package entry point.
+
+- **Verified:** exact dependency types preserved through the alias, container stays chainable,
+  works for both chained and composed containers, and the alias name survives into real
+  diagnostics when consumed from the built `dist/`.
+- Full gate green: `pnpm build`, `pnpm test` (82 tests + type tests), `pnpm lint`.
 
 ### 5. CI perf regression gate ⬜
 

--- a/docs/type-performance-plan.md
+++ b/docs/type-performance-plan.md
@@ -247,8 +247,9 @@ version. `SealedContainer` and `ResolversOf` are now exported from the package e
 ### 5. CI perf regression gate ✅ **Done**
 
 `scripts/bench-types.mjs`, wired into CI as the `types-perf` job and runnable locally with
-`pnpm bench:types`. Three scenarios, each gated on a type-instantiation budget (~25% headroom
-over the measured value on TypeScript 7.0.2):
+`pnpm bench:types` — see [type-benchmarks.md](./type-benchmarks.md) for how to read its report.
+Three scenarios, each gated on a type-instantiation budget (~25% headroom over the measured value
+on TypeScript 7.0.2):
 
 | Scenario        | What it guards                               | Measured | Budget |
 | --------------- | -------------------------------------------- | -------: | -----: |

--- a/docs/type-performance-plan.md
+++ b/docs/type-performance-plan.md
@@ -41,7 +41,7 @@ one finding (the crash) did not survive the last one.
 | 2   | Guardrail the single-chain crash                                           | —                                 | —       | ➖ **Obsolete on TS 7** (no crash); item 1 covers it |
 | 3   | Constant-factor type cleanups (`add`/`update` signatures)                  | Low–Med                           | Low     | ✅ **Done**                                          |
 | 4   | Escape hatch for consumers (seal container behind a named type)            | Low (readability only)            | Low     | ✅ **Done** (premise disproved; shipped as DX only)  |
-| 5   | CI perf regression gate (benchmark harness)                                | Med (prevents regressions)        | Low     | ⬜ Not started                                       |
+| 5   | CI perf regression gate (benchmark harness)                                | Med (prevents regressions)        | Low     | ✅ **Done** (`pnpm bench:types`, CI `types-perf`)    |
 
 ---
 
@@ -244,18 +244,43 @@ version. `SealedContainer` and `ResolversOf` are now exported from the package e
   diagnostics when consumed from the built `dist/`.
 - Full gate green: `pnpm build`, `pnpm test` (82 tests + type tests), `pnpm lint`.
 
-### 5. CI perf regression gate ⬜
+### 5. CI perf regression gate ✅ **Done**
 
-Add a types-perf benchmark to CI (see appendix): generate an N-chain and assert
-instantiations/check-time under a threshold via `tsc --extendedDiagnostics`, alongside the
-existing `--typecheck` tests, so no future change silently reintroduces the blow-up.
+`scripts/bench-types.mjs`, wired into CI as the `types-perf` job and runnable locally with
+`pnpm bench:types`. Three scenarios, each gated on a type-instantiation budget (~25% headroom
+over the measured value on TypeScript 7.0.2):
+
+| Scenario        | What it guards                               | Measured | Budget |
+| --------------- | -------------------------------------------- | -------: | -----: |
+| `chain-200`     | per-`add` constant factor on a flat chain    |     268K |   330K |
+| `compose-400`   | the `compose` path, 400 deps as 20 modules   |      97K |   130K |
+| `compose-scale` | 60 composed containers — depth-limiter guard |      35K |    45K |
+
+**Why this is not redundant with the type tests.** The `*.test-d.ts` assertions run at three or
+four dependencies. Both known failure modes are invisible at that size — verified by
+reintroducing each one and running the full suite:
+
+| Reintroduced regression                     | `pnpm test`             | `pnpm bench:types`          |
+| ------------------------------------------- | ----------------------- | --------------------------- |
+| recursive tuple fold in `MergedResolvers`   | 82 passed, no errors ✅ | FAILED — TS2589 + `never` ✗ |
+| `Simplify` flatten on the `add` accumulator | 82 passed, no errors ✅ | FAILED — 507× TS2589 ✗      |
+
+Every fixture also asserts exact types via a compile-time `Exact<>` check, so the gate cannot be
+satisfied by making inference _worse_: a change degrading everything to `any` would lower the
+instantiation count but fail the assertions. The budget path was verified independently by
+lowering a budget below the measured value.
+
+Budgets are compiler-specific. A TypeScript upgrade moves the numbers — run the script, read the
+reported actuals, and re-baseline in the same commit as the upgrade.
 
 ---
 
 ## Appendix — reproducing the benchmark
 
-The harness used for this analysis is straightforward to regenerate (kept out of the repo to
-avoid shipping scratch tooling; item 5 would formalize it).
+The gated scenarios now live in `scripts/bench-types.mjs` (`pnpm bench:types`) — start there, and
+add a scenario to it rather than rebuilding a one-off harness. The notes below cover the ad-hoc
+exploration that produced the tables above: sweeping N, comparing layouts, and ablating individual
+pieces of the type machinery, none of which the committed script does.
 
 **Generator** — emit an N-length chain that imports the real container and destructures prior deps:
 

--- a/docs/type-performance-plan.md
+++ b/docs/type-performance-plan.md
@@ -99,8 +99,15 @@ Instantiations quadruple per doubling — textbook O(N²). No crash at any lengt
 At 1600 dependencies that is **~22× fewer instantiations and ~100× faster**. The win grows
 with N, because the flat chain is quadratic and the composed layout is not.
 
-Module _size_ matters more than module count: 20–40 dependencies per module is the sweet
-spot, and past that the returns flatten (m=40 vs m=80 at N=1600 differ by <25%).
+Module size matters only for modules built from an **empty** container, where total cost is
+roughly `N × size` — halving the size halves the quadratic part (m=40 vs m=80 at N=1600 differ
+by ~19%). For a module **seeded** with a large declared map the seed dominates instead, and
+splitting barely helps: the same 64 dependencies on a 300-key seed cost 38.1K instantiations as
+one module, 37.1K as two, 36.3K as four — under 5% across a 4× split.
+
+So ~64 `add` calls in one module is a comfortable ceiling rather than a warning sign, and
+`module-seeded-64` guards it. Below that, module size is a readability decision, not a
+performance one; the thing that actually costs is wiring the whole graph as a single chain.
 
 ### The `extend` pattern scales too (and keeps cross-module types)
 

--- a/docs/type-performance-plan.md
+++ b/docs/type-performance-plan.md
@@ -1,0 +1,203 @@
+# RSDI type-performance plan
+
+> **Audience:** AI agents and maintainers continuing work on the "heavy types" pain point.
+> **Context:** In large projects (hundreds–thousands of dependencies) the container's
+> types get expensive to check and, past a threshold, crash `tsc` outright. This doc
+> captures the root-cause analysis, the measured evidence, what does **not** help, and
+> the ranked improvement plan with status.
+
+All numbers below were measured with the repo's own **TypeScript 6.0.3** under `strict`,
+via `tsc --extendedDiagnostics`. **Instantiation counts are deterministic** and are the
+reliable metric; wall-clock check-time is single-run noise (±0.15s) — treat it as indicative only.
+
+---
+
+## TL;DR
+
+- Each `.add()` returns `IDIContainer<CR & { [n in N]: … }>`. The container type **is** the
+  full dependency map, re-embedded at every link. Type-checking link *k* is **O(k)**, so a
+  chain of N adds is **O(N²)**. This is inherent to any fluent builder that exposes exact
+  per-key types — not a bug in the type code.
+- **Two cliffs:** (1) O(N²) makes big projects slow to check; (2) a **single fluent
+  `.add().add()…` expression of ~500–600 links crashes `tsc`** with
+  `RangeError: Maximum call stack size exceeded` — this is **AST depth**, independent of
+  the type design (even a minimal container type crashes at the same length).
+- **The real fix for "thousands" is composition** (split into modules, `merge`/`extend`):
+  it turns O(N²) into ~O(N²/m + N) and keeps every chain short. Everything else is
+  constant-factor cleanup or guardrails.
+
+---
+
+## Status of the plan
+
+| # | Item | Impact | Risk | Status |
+|---|------|--------|------|--------|
+| 1 | Make modular composition first-class (`compose`/`register` helper + docs) | **High** (the scalability answer) | Low–Med | ⬜ Not started |
+| 2 | Guardrail the single-chain crash (array-based API + docs) | Med (prevents hard failure) | Low | ⬜ Not started |
+| 3 | Constant-factor type cleanups (`add`/`update` signatures) | Low–Med | Low | ✅ **Done** |
+| 4 | Escape hatch for consumers (seal container behind a named type) | Med (downstream files) | Low | ⬜ Not started |
+| 5 | CI perf regression gate (benchmark harness) | Med (prevents regressions) | Low | ⬜ Not started |
+
+---
+
+## Root cause
+
+`IDIContainer<CR> = CR & { add; get; update; merge; extend; clone; has; … }`, and
+`add` returns `IDIContainer<CR & { [n in N]: V }>`. To type-check link *k* against a
+*k*-key map, TypeScript must:
+
+1. resolve `.add` on a *k*-constituent intersection (`CR & { …methods }`);
+2. compute `keyof CR` for the `DenyInputKeys` duplicate-name guard;
+3. relate the factory to `(resolvers: CR) => V` and resolve any destructured deps
+   (`({ a, b }) =>`) against the *k*-key map;
+4. build the next `CR & { new }` and re-instantiate the **recursive** `IDIContainer` alias.
+
+Each is **O(k)** ⇒ whole chain **O(N²)**.
+
+The ~500–600-link **crash** is a separate mechanism: one `.add().add()…` mega-expression
+is a 500+-deep syntax tree, and `tsc`'s parent-node walkers (e.g. `getAssignmentDeclarationKind`)
+overflow the JS call stack. Splitting the identical adds into separate statements removes
+the crash (but stays O(N²)).
+
+---
+
+## Measured evidence
+
+Faithfulness check: an inlined model of `types.ts` reproduced the **real** `src/DIContainer.ts`
+cost to within ~1.5% (266,569 vs 262,853 instantiations at N=200), so the model-based
+ablations below are trustworthy.
+
+### Single fluent chain scales quadratically, then crashes
+
+| Scenario (TS 6.0.3, strict) | Instantiations | Check time | Result |
+|---|---:|---:|---|
+| chain N=100 | 71K | 0.20s | ok |
+| chain N=200 (real `src/`) | 266K | 0.81s | ok |
+| chain N=400 | 674K–1.02M | 3.9–4.2s | slow |
+| **chain N≈600** | — | — | **`RangeError: Maximum call stack size exceeded`** |
+
+Crash threshold is between **500 (ok)** and **600 (crash)** links. Confirmed design-independent
+(a bare minimal container type crashes at 600 too). Same 800 adds as **separate statements**
+do **not** crash (they compile in ~30s / ~3.9M instantiations).
+
+### Composition breaks the quadratic (N=400, current types)
+
+| Layout | Instantiations | Check time |
+|---|---:|---:|
+| 1 × 400 (one chain) | 674K | 3.85s |
+| 4 × 100 | 196K | 0.52s |
+| 8 × 50 | 117K | 0.31s |
+| **20 × 20** | **74K** | **0.28s** |
+
+≈9× fewer instantiations, ≈14× faster — **and** every module chain stays short (fast editor
+feedback, no crash risk).
+
+### Cost decomposition (per-`add`, N=400, no-deref)
+
+| Variant | Instantiations | vs full |
+|---|---:|---:|
+| full `add` (guard + `Factory<CR>` constraint) | 674K | — |
+| drop `keyof` duplicate-guard | 496K | −26% |
+| drop `Factory<CR>` constraint | 350K | −48% |
+| drop both ("bare") | 172K | −75% (still O(N²)) |
+
+Even the bare minimum is quadratic. The two removable hotspots (`keyof` guard, `Factory`
+constraint) only pay off when factories **don't** read their deps; real factories destructure
+`CR`, so that cost is unavoidable.
+
+---
+
+## What does NOT help (ruled out — don't re-attempt)
+
+- **Naive `Simplify`/`Prettify` flatten** on the accumulator (`{ [K in keyof T]: T[K] }`):
+  trips TS's depth limiter (**TS2589**) at ~50 links and silently collapses inference to
+  `never`. Actively harmful.
+- **Removing methods** (`get/update/merge/extend/clone/has`) or the **`CR &` property-access
+  sugar**: ≈0% change. They're only instantiated on the final type, not per step. The cost
+  is `add` alone.
+- **Dropping `ReturnType<R>` for an inferred `V`** (item 3): only ~1% once factories read
+  their deps. Worth doing for simplicity, not for speed.
+
+---
+
+## The plan
+
+### 1. Make modular composition first-class — *the actual fix for "thousands"* ⬜
+
+Splitting N deps into *m* modules and combining cuts build cost ~*m*× (O(N²)→O(N²/m + N))
+and keeps each chain short. `merge`/`extend` already exist; the work is ergonomics + docs:
+
+- Add a composition helper so users never write one giant chain — e.g.
+  `DIContainer.compose(moduleA, moduleB, …)` or `container.register(fnA, fnB, …)` folding
+  `extend`. A **rest/array-argument** form is important: it also sidesteps the AST-depth crash.
+- Prominent README/docs guidance: "for large graphs, split into feature modules and
+  `merge`/`extend`."
+- Verify the helper's own type cost stays ~linear in module count (the 20×20 data suggests it does).
+
+### 2. Guardrail the single-chain crash ⬜
+
+Even after everything else, ~500+ links in one expression stack-overflow `tsc`. Document a
+soft cap ("keep any single `.add()` chain to a few hundred; beyond that, compose") and prefer
+the array-based `register([...])` API from item 1, which avoids the giant-expression AST entirely.
+
+### 3. Constant-factor type cleanups ✅ **Done**
+
+Replaced `add`/`update`'s `<N, R extends Factory<CR>> … ReturnType<R>` with
+`<N, V>(resolver: Factory<CR, V>) … { [n in N]: V }`, and gave `Factory` an optional
+return-type param (`Factory<CR, Value = ResolvedDependencyValue>`, backward-compatible). Also
+dropped the redundant `& this` from the `add`/`update` return casts (internal-cast cleanup;
+declared return type unchanged). Two fewer moving parts per call site; one generic instead of two.
+
+- **Verified:** exact inference preserved (literal widening `() => 123` → `number`, `update`
+  override, factories reading prior deps, duplicate-name / unknown-dep still error).
+- Full gate green: `pnpm build`, `pnpm test` (42 tests + type tests), `npx eslint`.
+- Measured: N=200 deref 266,569 → 263,808 (−1%); no-deref ~177K → 140,255 (−20%).
+
+### 4. Escape hatch for downstream consumers ⬜
+
+Document sealing the built container behind a single named type —
+`export type AppContainer = ReturnType<typeof buildContainer>` — so files that *consume* the
+container reference one materialized type instead of re-deriving the whole builder chain.
+Optionally offer an opt-in loose/index-signature mode for extreme scale.
+
+### 5. CI perf regression gate ⬜
+
+Add a types-perf benchmark to CI (see appendix): generate an N-chain and assert
+instantiations/check-time under a threshold via `tsc --extendedDiagnostics`, alongside the
+existing `--typecheck` tests, so no future change silently reintroduces the blow-up.
+
+---
+
+## Appendix — reproducing the benchmark
+
+The harness used for this analysis is straightforward to regenerate (kept out of the repo to
+avoid shipping scratch tooling; item 5 would formalize it).
+
+**Generator** — emit an N-length chain that imports the real container and destructures prior deps:
+
+```js
+// gen.mjs <N>
+import { writeFileSync } from 'node:fs';
+const n = Number(process.argv[2]);
+let s = `import { DIContainer } from '../../src/DIContainer.js';\n`;
+s += `const c0 = new DIContainer().add('k0', () => ({ v: 0 }));\n`;
+s += `const c1 = c0.add('k1', () => ({ v: 1 }));\n`;
+for (let i = 2; i < n; i++)
+  s += `const c${i} = c${i - 1}.add('k${i}', ({ k${i - 1}, k${i - 2} }) => ({ v: k${i - 1}.v + k${i - 2}.v }));\n`;
+writeFileSync(`chain_${n}.ts`, s);
+```
+
+Use **per-statement** form (as above) to measure type cost without the AST-depth crash;
+use one `.add().add()…` expression to reproduce the crash.
+
+**Measure** (note TS 6 needs `--ignoreConfig` when a tsconfig is present and files are passed):
+
+```bash
+tsc --noEmit --ignoreConfig --extendedDiagnostics --strict --skipLibCheck \
+  --module nodenext --moduleResolution nodenext chain_200.ts
+# read "Instantiations:" (deterministic) and "Check time:" (noisy)
+```
+
+Ablation knobs used above: with/without factory dep destructuring ("deref"/"noderef");
+with/without the `keyof` duplicate-guard; with/without the `Factory<CR>` constraint; and
+composition layouts (m modules of N/m combined via `merge`).

--- a/docs/type-performance-plan.md
+++ b/docs/type-performance-plan.md
@@ -109,6 +109,36 @@ N=800 as 20 modules costs **187K / 0.19s** — same order as `compose`, versus 1
 for the flat chain. Use `extend` when a module needs a previous module's types while it is
 being written; use `compose` for independently built modules.
 
+### Field report — a real ~340-dependency application
+
+Numbers contributed by a production TypeScript monorepo (TS 5.9.3, strict, NodeNext) that integrated
+this branch. These supersede the synthetic `extend` result above, and are the reason the guidance now
+says _isolation_, not _splitting_.
+
+| Container shape                                        | Instantiations |         Types |
+| ------------------------------------------------------ | -------------: | ------------: |
+| flat single chain (~340 `add` calls), published 3.0.4  |      3,489,505 |     1,268,004 |
+| flat single chain, this branch                         |      3,412,439 |     1,283,956 |
+| split into `.extend()` modules threading the full type |      3,482,677 |     1,296,179 |
+| `compose` + leaf seeds via `Pick<FullMap, …>`          |      3,412,208 |     1,216,240 |
+| **`compose` + explicit `{…}` leaf seeds**              |  **3,411,796** | **1,216,203** |
+
+Three findings worth keeping:
+
+1. **The upgrade is a clean −2.2%** on real code with dependency-reading factories, with no inference
+   regression — consistent with the ~1% predicted for the deref-heavy case in item 3.
+2. **Splitting alone does nothing.** `.extend()` modules that thread the accumulated container measured
+   _worse_ than the flat chain. The win is not the file boundary, it is checking a module against a
+   small declared surface: the five composed leaves cost **68.7 ms** combined versus **924.8 ms** as
+   `extend` modules — **~13×** — visible in `--generateTrace`, not in the instantiation total.
+3. **`Pick<FullMap, …>` as a leaf seed is a trap.** It normalises the entire ~300-key accumulated
+   intersection to select a few keys. Explicit `{ a: A; b: B }` interfaces were faster _and_ decoupled.
+
+They also report that dropping explicit module return annotations in favour of
+`ReturnType<typeof previousModule>` removes the per-module depth firewall: on a stricter `add` typing it
+went from 7 errors to **208**, with the container collapsing to `never`. Explicit named boundary types are
+the robust choice on long chains; this is now documented in the README and the agent guide.
+
 ### Cost decomposition (per-`add`, N=400, no-deref)
 
 | Variant                                       | Instantiations |            vs full |
@@ -142,6 +172,14 @@ constraint) only pay off when factories **don't** read their deps; real factorie
 - **Sealing/flattening the container type for consumer files** (item 4): consumers are already
   cheap (~2.6K instantiations per file, cached per program), and sealing costs ~3% _more_.
   Useful for readable error messages only — never as a performance fix.
+- **An eager mapped type for `add`'s return** —
+  `Add<T, N, V> = { [K in keyof T | N]: K extends N ? V : K extends keyof T ? T[K] : never }`
+  instead of the lazy `T & { [n in N]: V }`. It re-maps every accumulated key on **every** `add`, so
+  nested `Add<Add<Add<…>>>` re-evaluates the whole map per layer. Reproduced here: a module of **64**
+  `add` calls on a 300-key seed throws 15× TS2589 on both TS 7.0.2 and TS 5.9.3, while the shipped
+  lazy `&` is clean at 64, 100, and at a 500-key seed. Flatter hover text is not worth the depth
+  headroom; flatten at a named boundary (`SealedContainer`) instead. Guarded by the
+  `module-seeded-64` scenario.
 
 ---
 
@@ -251,11 +289,17 @@ version. `SealedContainer` and `ResolversOf` are now exported from the package e
 Three scenarios, each gated on a type-instantiation budget (~25% headroom over the measured value
 on TypeScript 7.0.2):
 
-| Scenario        | What it guards                               | Measured | Budget |
-| --------------- | -------------------------------------------- | -------: | -----: |
-| `chain-200`     | per-`add` constant factor on a flat chain    |     268K |   330K |
-| `compose-400`   | the `compose` path, 400 deps as 20 modules   |      97K |   130K |
-| `compose-scale` | 60 composed containers — depth-limiter guard |      35K |    45K |
+| Scenario           | What it guards                                           | Measured | Budget |
+| ------------------ | -------------------------------------------------------- | -------: | -----: |
+| `chain-200`        | per-`add` constant factor on a flat chain                |     268K |   330K |
+| `compose-400`      | the `compose` path, 400 deps as 20 modules               |      97K |   130K |
+| `compose-scale`    | 60 composed containers — depth-limiter guard             |      35K |    45K |
+| `module-seeded-64` | 64 `add` calls on a 300-key seed — the real-module shape |      38K |    48K |
+
+`module-seeded-64` was added after the field report. The seed is the load-bearing part: starting from
+an _empty_ container understates per-`add` cost, so an eager-mapped-type regression that breaks real
+code at 64 chained calls only surfaces around 200 from empty. Both scenarios catch it now, but only
+this one catches it at the size real modules reach.
 
 **Why this is not redundant with the type tests.** The `*.test-d.ts` assertions run at three or
 four dependencies. Both known failure modes are invisible at that size — verified by

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     }
   },
   "scripts": {
+    "bench:types": "node scripts/bench-types.mjs",
     "build": "tsc",
     "format": "oxfmt --threads=1 && oxlint --type-aware --type-check --quiet --fix",
     "lint": "oxfmt --threads=1 --check && oxlint --type-aware --type-check --quiet --format unix",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "author": "Sergey Radzishevskii <radzserg@gmail.com>",
   "files": [
     "dist/**",
-    "!dist/**/__tests__/**"
+    "!dist/**/__tests__/**",
+    "docs/ai-agent-guide.md"
   ],
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/bench-types.mjs
+++ b/scripts/bench-types.mjs
@@ -45,6 +45,7 @@ const BUDGETS = {
   'chain-200': 330_000,
   'compose-400': 130_000,
   'compose-scale': 45_000,
+  'module-seeded-64': 48_000,
 };
 
 const EXACT = `type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;\n`;
@@ -62,6 +63,38 @@ const chainFixture = (n) => {
   s += `const container = c${n - 1};\n`;
   s += `export const exactValue: Exact<typeof container.k${n - 1}, { v: number }> = true;\n`;
   s += `export const exactGet: Exact<ReturnType<typeof container.get<'k0'>>, { v: number }> = true;\n`;
+  return s;
+};
+
+/**
+ * A single domain module chained on top of an already-large container — the shape real
+ * applications actually have, and the one that breaks first.
+ *
+ * The seed is the load-bearing part. Starting from an empty container understates the cost
+ * per `add`, because every candidate return type is evaluated against a map that is still
+ * small. A field report from a ~340-dependency application hit TS2589 in a module of 64
+ * `add` calls layered on ~300 existing keys; reproduced here, that shape errors at 64 while
+ * an empty-start chain of the same length is clean, and stays clean until ~200. Without this
+ * scenario a regression that breaks real code at 64 could pass `chain-200`.
+ */
+const seededModuleFixture = (adds, seed) => {
+  let s = `import { DIContainer } from '../../src/DIContainer.js';\n${EXACT}\n`;
+  s += `type Seed = {\n`;
+  for (let i = 0; i < seed; i++) {
+    s += `  s${i}: { v: number; name: string };\n`;
+  }
+
+  s += `};\n\nconst container = new DIContainer<Seed>()\n`;
+  for (let i = 0; i < adds; i++) {
+    s +=
+      i === 0
+        ? `  .add('n0', ({ s0 }) => ({ v: s0.v, name: 'n0' }))\n`
+        : `  .add('n${i}', ({ s${i % seed}, n${i - 1} }) => ` +
+          `({ v: s${i % seed}.v + n${i - 1}.v, name: 'n${i}' }))\n`;
+  }
+  s += `;\n`;
+  s += `export const exactAdded: Exact<typeof container.n${adds - 1}, { v: number; name: string }> = true;\n`;
+  s += `export const exactSeed: Exact<typeof container.s0, { v: number; name: string }> = true;\n`;
   return s;
 };
 
@@ -119,6 +152,11 @@ const SCENARIOS = [
     build: () => composeScaleFixture(60),
     name: 'compose-scale',
     what: '60 composed containers (depth-limiter guard)',
+  },
+  {
+    build: () => seededModuleFixture(64, 300),
+    name: 'module-seeded-64',
+    what: '64 add() calls on top of a 300-key container (real-module shape)',
   },
 ];
 

--- a/scripts/bench-types.mjs
+++ b/scripts/bench-types.mjs
@@ -48,7 +48,19 @@ const BUDGETS = {
   'module-seeded-64': 48_000,
 };
 
-const EXACT = `type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;\n`;
+// `[any] extends [T]` and `[T] extends [any]` are both true, so a plain bidirectional-extends
+// check reports `Exact<any, Something>` as a match. That would leave the gate blind to the worst
+// possible regression: inference collapsing to `any` type-checks everything *and* lowers the
+// instantiation count, so it would come in comfortably under budget. Reject `any` on either side.
+const EXACT =
+  `type IsAny<T> = 0 extends 1 & T ? true : false;\n` +
+  `type Exact<A, B> = IsAny<A> extends true\n` +
+  `  ? false\n` +
+  `  : IsAny<B> extends true\n` +
+  `    ? false\n` +
+  `    : [A] extends [B]\n` +
+  `      ? ([B] extends [A] ? true : false)\n` +
+  `      : false;\n`;
 
 /** A flat chain — the shape that costs O(N²). Guards the per-`add` constant factor. */
 const chainFixture = (n) => {

--- a/scripts/bench-types.mjs
+++ b/scripts/bench-types.mjs
@@ -1,0 +1,222 @@
+// Guards the type-level cost of building a container, and the inference that
+// makes that cost worth paying.
+//
+// Why this exists: the whole value of this package is per-key inference, and the
+// machinery that produces it is quadratic by construction — each `add` re-embeds
+// the growing resolver map, so a chain of N dependencies costs O(N²) to check.
+// That makes it easy to add a small-looking type and multiply everyone's build
+// time, with nothing in the normal test run to notice. `docs/type-performance-plan.md`
+// has the measurements.
+//
+// It also guards two failure modes that are *silent* — they produce no error at
+// the size the type tests use, and only degrade once a real app hits them:
+//
+//   - A recursive tuple fold in `MergedResolvers` (instead of the current
+//     union-to-intersection fold) trips TS2589 at ~50 composed containers and
+//     collapses inference to `never`.
+//   - A `Simplify`-style flatten on the accumulator does the same at ~50 chained
+//     `add` calls.
+//
+// Both look fine with three dependencies. The `compose-scale` scenario below uses
+// enough containers to reach them.
+//
+// Every fixture asserts exact types as well as staying under a budget: a change
+// that degraded inference to `any` would be *faster*, so a budget alone would wave
+// it through. Any `tsc` diagnostic fails the scenario.
+//
+// Budgets are compiler-specific. When TypeScript is upgraded the numbers move and
+// the budgets need re-baselining — run this script, read the reported actuals, and
+// update BUDGETS in the same commit as the upgrade.
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, '..');
+// Fixtures live under node_modules so they are ignored by git and can import
+// ../../src with a relative specifier.
+const workDir = join(repoRoot, 'node_modules', '.types-bench');
+const tsc = join(repoRoot, 'node_modules', '.bin', 'tsc');
+
+// Instantiation ceilings, ~25% above the measured value on TypeScript 7.0.2.
+// The headroom absorbs patch-level compiler noise; a real regression is far larger.
+const BUDGETS = {
+  'chain-200': 330_000,
+  'compose-400': 130_000,
+  'compose-scale': 45_000,
+};
+
+const EXACT = `type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;\n`;
+
+/** A flat chain — the shape that costs O(N²). Guards the per-`add` constant factor. */
+const chainFixture = (n) => {
+  let s = `import { DIContainer } from '../../src/DIContainer.js';\n${EXACT}\n`;
+  s += `const c0 = new DIContainer().add('k0', () => ({ v: 0 }));\n`;
+  s += `const c1 = c0.add('k1', () => ({ v: 1 }));\n`;
+  for (let i = 2; i < n; i++) {
+    s +=
+      `const c${i} = c${i - 1}.add('k${i}', ({ k${i - 1}, k${i - 2} }) => ` +
+      `({ v: k${i - 1}.v + k${i - 2}.v }));\n`;
+  }
+  s += `const container = c${n - 1};\n`;
+  s += `export const exactValue: Exact<typeof container.k${n - 1}, { v: number }> = true;\n`;
+  s += `export const exactGet: Exact<ReturnType<typeof container.get<'k0'>>, { v: number }> = true;\n`;
+  return s;
+};
+
+/** The recommended layout: independent modules combined with `compose`. */
+const composeFixture = (n, m) => {
+  let s = `import { DIContainer } from '../../src/DIContainer.js';\n${EXACT}\n`;
+  const size = n / m;
+  for (let mod = 0; mod < m; mod++) {
+    s += `const mod${mod} = new DIContainer()\n`;
+    for (let j = 0; j < size; j++) {
+      const g = mod * size + j;
+      s += `  .add('k${g}', () => ({ v: ${g} }))\n`;
+    }
+    s += `;\n`;
+  }
+  const args = Array.from({ length: m }, (_, i) => `mod${i}`).join(', ');
+  s += `const container = DIContainer.compose(${args});\n`;
+  s += `export const exactFirst: Exact<typeof container.k0, { v: number }> = true;\n`;
+  s += `export const exactLast: Exact<typeof container.k${n - 1}, { v: number }> = true;\n`;
+  return s;
+};
+
+/**
+ * Enough composed containers to reach the depth limiter, with mixed value types so
+ * a fold that degrades to `never` cannot satisfy the assertions.
+ */
+const composeScaleFixture = (m) => {
+  let s = `import { DIContainer } from '../../src/DIContainer.js';\n${EXACT}\n`;
+  for (let mod = 0; mod < m; mod++) {
+    s +=
+      `const mod${mod} = new DIContainer()` +
+      `.add('num${mod}', () => ${mod}).add('str${mod}', () => 'v${mod}');\n`;
+  }
+  const args = Array.from({ length: m }, (_, i) => `mod${i}`).join(', ');
+  s += `const container = DIContainer.compose(${args});\n`;
+  // Sample across the range: a fold that gives up part-way still fails here.
+  for (const mod of [0, Math.floor(m / 2), m - 1]) {
+    s += `export const exactNum${mod}: Exact<typeof container.num${mod}, number> = true;\n`;
+    s += `export const exactStr${mod}: Exact<typeof container.str${mod}, string> = true;\n`;
+  }
+  // Still chainable, and prior dependencies stay visible to factories.
+  s += `const extended = container.add('joined', ({ num0, str0 }) => \`\${num0}\${str0}\`);\n`;
+  s += `export const exactJoined: Exact<typeof extended.joined, string> = true;\n`;
+  return s;
+};
+
+const SCENARIOS = [
+  { build: () => chainFixture(200), name: 'chain-200', what: 'flat chain of 200 add() calls' },
+  {
+    build: () => composeFixture(400, 20),
+    name: 'compose-400',
+    what: '400 dependencies as 20 composed modules',
+  },
+  {
+    build: () => composeScaleFixture(60),
+    name: 'compose-scale',
+    what: '60 composed containers (depth-limiter guard)',
+  },
+];
+
+const measure = (name, source) => {
+  const file = join(workDir, `${name}.ts`);
+  writeFileSync(file, source);
+
+  let output;
+  try {
+    output = execFileSync(
+      tsc,
+      [
+        '--noEmit',
+        '--ignoreConfig',
+        '--extendedDiagnostics',
+        '--strict',
+        '--skipLibCheck',
+        '--target',
+        'es2022',
+        '--lib',
+        'es2022',
+        '--module',
+        'nodenext',
+        '--moduleResolution',
+        'nodenext',
+        file,
+      ],
+      { cwd: repoRoot, encoding: 'utf8' },
+    );
+  } catch (error) {
+    // A non-zero exit means diagnostics; keep the output so they can be reported.
+    output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
+  }
+
+  const instantiations = Number(/^Instantiations:\s*(\d+)$/m.exec(output)?.[1] ?? Number.NaN);
+  const diagnostics = output
+    .split('\n')
+    .filter((line) => /error TS\d+/.test(line))
+    .map((line) => line.trim());
+
+  return { diagnostics, instantiations };
+};
+
+rmSync(workDir, { force: true, recursive: true });
+mkdirSync(workDir, { recursive: true });
+
+let failed = false;
+console.log(
+  `types-bench: TypeScript ${execFileSync(tsc, ['--version'], { encoding: 'utf8' }).trim()}\n`,
+);
+
+for (const scenario of SCENARIOS) {
+  const budget = BUDGETS[scenario.name];
+  const { diagnostics, instantiations } = measure(scenario.name, scenario.build());
+
+  if (diagnostics.length > 0) {
+    failed = true;
+    console.error(`✗ ${scenario.name} — ${scenario.what}`);
+    console.error(`  inference broke: ${diagnostics.length} diagnostic(s)`);
+    for (const diagnostic of diagnostics.slice(0, 5)) {
+      console.error(`    ${diagnostic}`);
+    }
+
+    console.error(
+      `  A TS2589 here means a type in src/types.ts started recursing per dependency;\n` +
+        `  a failed Exact<> assertion means inference degraded. See docs/type-performance-plan.md.\n`,
+    );
+    continue;
+  }
+
+  if (!Number.isFinite(instantiations)) {
+    failed = true;
+    console.error(`✗ ${scenario.name} — could not read "Instantiations:" from tsc output\n`);
+    continue;
+  }
+
+  const percent = Math.round((instantiations / budget) * 100);
+  if (instantiations > budget) {
+    failed = true;
+    console.error(`✗ ${scenario.name} — ${scenario.what}`);
+    console.error(
+      `  ${instantiations.toLocaleString()} instantiations exceeds the ${budget.toLocaleString()} budget (${percent}%).\n` +
+        `  Something made the container types more expensive per dependency. If the increase\n` +
+        `  is understood and intended, raise the budget in scripts/bench-types.mjs and say why.\n`,
+    );
+  } else {
+    console.log(
+      `✓ ${scenario.name} — ${instantiations.toLocaleString()} / ${budget.toLocaleString()} instantiations (${percent}% of budget)`,
+    );
+    console.log(`    ${scenario.what}`);
+  }
+}
+
+rmSync(workDir, { force: true, recursive: true });
+
+if (failed) {
+  console.error('\ntypes-bench: FAILED');
+  process.exit(1);
+}
+
+console.log('\ntypes-bench: OK');

--- a/src/DIContainer.ts
+++ b/src/DIContainer.ts
@@ -4,9 +4,11 @@ import {
   ForbiddenNameError,
 } from './errors.js';
 import {
+  type ContainerLike,
   type DenyInputKeys,
   type Factory,
   type IDIContainer,
+  type MergedResolvers,
   type ResolvedDependencies,
   type ResolvedDependencyValue,
   type Resolvers,
@@ -44,6 +46,38 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
         return target[propertyName];
       },
     }) as unknown as ContainerResolvers;
+  }
+
+  /**
+   * Combines independently built containers into a single new container.
+   *
+   * This is the recommended way to wire a large dependency graph. Splitting the graph
+   * into modules and composing them is dramatically cheaper to type-check than one long
+   * `add` chain, because each module chain is type-checked against its own small
+   * resolver map instead of the ever-growing combined one:
+   *
+   * // repositories.ts
+   * export const repositories = new DIContainer().add('userRepository', () => new UserRepository());
+   * // services.ts
+   * export const services = new DIContainer().add('mailer', () => new Mailer());
+   * // container.ts
+   * const container = DIContainer.compose(repositories, services);
+   *
+   * Factories may depend on names provided by any of the composed containers — resolution
+   * happens lazily against the composed container, so cross-module dependencies work at
+   * runtime. Only the *types* of a module are limited to what that module declares; when a
+   * module needs another module's dependencies to be visible at compile time, layer them
+   * with `extend` instead.
+   *
+   * The inputs are left untouched: the composed container is a new instance.
+   *
+   * When several containers define the same name the last one wins.
+   * @param containers
+   */
+  public static compose<T extends readonly ContainerLike[]>(
+    ...containers: T
+  ): IDIContainer<MergedResolvers<T>> {
+    return new DIContainer().merge(...containers) as IDIContainer<MergedResolvers<T>>;
   }
 
   /**
@@ -157,34 +191,47 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
   }
 
   /**
-   * Merges two containers. It will return a new container with merged resolvers. Resolved dependencies will be merged as well.
-   * @param otherContainer
+   * Merges other containers into this one. Resolved dependencies are merged as well.
+   *
+   * Accepts any number of containers, so a set of independently built modules can be
+   * combined in a single call:
+   *
+   * base.merge(repositories, services, controllers)
+   *
+   * Combining modules this way is also much cheaper to type-check than one long
+   * `add` chain — see docs/type-performance-plan.md.
+   *
+   * When several containers define the same name the last one wins, matching the
+   * behaviour of a chain of two-container merges.
+   *
+   * This mutates and returns `this`; use `clone()` or the static `DIContainer.compose()`
+   * when a separate instance is required.
+   * @param containers
    */
-  public merge<OtherContainerResolvers extends ResolvedDependencies>(
-    otherContainer: DIContainer<OtherContainerResolvers>,
-  ): IDIContainer<ContainerResolvers & OtherContainerResolvers> {
-    const { resolvedDependencies: newResolvedDependencies, resolvers: newResolvers } =
-      otherContainer.export();
+  public merge<T extends readonly ContainerLike[]>(
+    ...containers: T
+  ): IDIContainer<ContainerResolvers & MergedResolvers<T>> {
+    for (const otherContainer of containers) {
+      const { resolvedDependencies: newResolvedDependencies, resolvers: newResolvers } = (
+        otherContainer as DIContainer<ResolvedDependencies>
+      ).export();
 
-    const resolvers = {
-      ...this.resolvers,
-      ...newResolvers,
-    };
+      this.resolvers = {
+        ...this.resolvers,
+        ...newResolvers,
+      };
 
-    const resolvedDependencies = {
-      ...this.resolvedDependencies,
-      ...newResolvedDependencies,
-    };
+      this.resolvedDependencies = {
+        ...this.resolvedDependencies,
+        ...newResolvedDependencies,
+      };
+    }
 
-    this.resolvers = resolvers;
-    this.resolvedDependencies = {
-      ...resolvedDependencies,
-    };
     for (const property of Object.keys(this.resolvers)) {
       this.addContainerProperty(property);
     }
 
-    return this as unknown as IDIContainer<ContainerResolvers & OtherContainerResolvers>;
+    return this as unknown as IDIContainer<ContainerResolvers & MergedResolvers<T>>;
   }
 
   /**

--- a/src/DIContainer.ts
+++ b/src/DIContainer.ts
@@ -15,9 +15,16 @@ import {
   type StringLiteral,
 } from './types.js';
 
+// Every public *instance* member, because `addContainerProperty` defines dependencies as own
+// properties that would otherwise shadow the method of the same name. `export` belongs here even
+// though it is rarely used directly: `merge` calls it on the containers passed to it, so a
+// dependency named `export` turned any `merge`/`compose` involving that container into a
+// `TypeError`. Statics (`compose`) never live on the instance and are deliberately absent.
+// `src/__tests__/reservedNames.test.ts` fails if a new public method is not listed here.
 const containerMethods = new Set([
   'add',
   'clone',
+  'export',
   'extend',
   'get',
   'has',
@@ -71,7 +78,12 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
    *
    * The inputs are left untouched: the composed container is a new instance.
    *
-   * When several containers define the same name the last one wins.
+   * When several containers define the same name the last one wins at runtime, including
+   * over a value the earlier container had already resolved. Note the types intersect rather
+   * than overwrite, so a name defined twice with *different* types resolves to `never` — a
+   * deliberate signal, since a scalable last-writer-wins type fold has to recurse per
+   * container and trips TypeScript's depth limiter at ~50 of them. Prefer `update()` when a
+   * replacement is intentional.
    * @param containers
    */
   public static compose<T extends readonly ContainerLike[]>(
@@ -201,8 +213,9 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
    * Combining modules this way is also much cheaper to type-check than one long
    * `add` chain — see docs/type-performance-plan.md.
    *
-   * When several containers define the same name the last one wins, matching the
-   * behaviour of a chain of two-container merges.
+   * When several containers define the same name the last one wins at runtime, including over
+   * an already-resolved value. The types intersect rather than overwrite, so the same name with
+   * two different types resolves to `never` rather than the later type.
    *
    * This mutates and returns `this`; use `clone()` or the static `DIContainer.compose()`
    * when a separate instance is required.
@@ -215,6 +228,18 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
       const { resolvedDependencies: newResolvedDependencies, resolvers: newResolvers } = (
         otherContainer as DIContainer<ResolvedDependencies>
       ).export();
+
+      // A replaced resolver must not keep the value the previous one produced — the same
+      // eviction `update()` performs. Only the overriding container's own cache may survive,
+      // so a name it re-registers without having resolved yet has to lose the old value;
+      // otherwise `merge`/`compose` return the earlier container's instance from a resolver
+      // that no longer exists, silently contradicting last-writer-wins.
+      for (const name of Object.keys(newResolvers)) {
+        if (!Object.hasOwn(newResolvedDependencies, name)) {
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete this.resolvedDependencies[name as keyof ContainerResolvers];
+        }
+      }
 
       this.resolvers = {
         ...this.resolvers,

--- a/src/DIContainer.ts
+++ b/src/DIContainer.ts
@@ -52,10 +52,10 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
    * @param name
    * @param resolver
    */
-  public add<N extends string, R extends Factory<ContainerResolvers>>(
+  public add<N extends string, V>(
     name: StringLiteral<DenyInputKeys<N, keyof ContainerResolvers>>,
-    resolver: R,
-  ): IDIContainer<ContainerResolvers & { [n in N]: ReturnType<R> }> {
+    resolver: Factory<ContainerResolvers, V>,
+  ): IDIContainer<ContainerResolvers & { [n in N]: V }> {
     if (containerMethods.has(name)) {
       throw new ForbiddenNameError(name);
     }
@@ -66,7 +66,7 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
 
     this.setValue(name, resolver);
 
-    return this as IDIContainer<ContainerResolvers & { [n in N]: ReturnType<R> }> & this;
+    return this as unknown as IDIContainer<ContainerResolvers & { [n in N]: V }>;
   }
 
   /**
@@ -196,12 +196,12 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
    * @param name
    * @param resolver
    */
-  public update<N extends keyof ContainerResolvers, R extends Factory<ContainerResolvers>>(
+  public update<N extends keyof ContainerResolvers, V>(
     name: StringLiteral<N>,
-    resolver: R,
+    resolver: Factory<ContainerResolvers, V>,
   ): IDIContainer<
     {
-      [n in N]: ReturnType<R>;
+      [n in N]: V;
     } & {
       [P in Exclude<keyof ContainerResolvers, N>]: ContainerResolvers[P];
     }
@@ -222,12 +222,11 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
 
     return this as unknown as IDIContainer<
       {
-        [n in N]: ReturnType<R>;
+        [n in N]: V;
       } & {
         [P in Exclude<keyof ContainerResolvers, N>]: ContainerResolvers[P];
       }
-    > &
-      this;
+    >;
   }
 
   protected setResolvers<CR extends ResolvedDependencies>(

--- a/src/__tests__/__typetests__/testTypes.test-d.ts
+++ b/src/__tests__/__typetests__/testTypes.test-d.ts
@@ -37,6 +37,62 @@ describe('DIContainer typescript type resolution', () => {
     expectTypeOf(container.a).toEqualTypeOf<string>();
   });
 
+  test('merge several containers in a single call', () => {
+    const containerA = new DIContainer().add('a', () => 'string');
+    const containerB = new DIContainer().add('b', () => new Date());
+    const containerC = new DIContainer().add('c', () => 123);
+
+    const container = containerA.merge(containerB, containerC);
+
+    expectTypeOf(container.a).toEqualTypeOf<string>();
+    expectTypeOf(container.b).toEqualTypeOf<Date>();
+    expectTypeOf(container.c).toEqualTypeOf<number>();
+  });
+
+  test('compose containers', () => {
+    const containerA = new DIContainer().add('a', () => 'string');
+    const containerB = new DIContainer().add('b', () => new Date());
+    const containerC = new DIContainer().add('bar', () => new Bar());
+
+    const container = DIContainer.compose(containerA, containerB, containerC);
+
+    expectTypeOf(container.a).toEqualTypeOf<string>();
+    expectTypeOf(container.b).toEqualTypeOf<Date>();
+    expectTypeOf(container.bar).toEqualTypeOf<Bar>();
+  });
+
+  test('compose keeps the container chainable', () => {
+    const containerA = new DIContainer().add('a', () => '1');
+    const containerB = new DIContainer().add('bar', () => new Bar());
+
+    const container = DIContainer.compose(containerA, containerB).add(
+      'foo',
+      ({ a, bar }) => new Foo(a, bar),
+    );
+
+    expectTypeOf(container.a).toEqualTypeOf<string>();
+    expectTypeOf(container.bar).toEqualTypeOf<Bar>();
+    expectTypeOf(container.foo).toEqualTypeOf<Foo>();
+  });
+
+  test('compose accepts a container with no resolvers', () => {
+    const containerA = new DIContainer().add('a', () => 'string');
+
+    const container = DIContainer.compose(new DIContainer(), containerA);
+
+    expectTypeOf(container.a).toEqualTypeOf<string>();
+  });
+
+  test('compose keeps the declared dependencies of a module', () => {
+    const bars = new DIContainer().add('bar', () => new Bar());
+    const foos = new DIContainer<{ bar: Bar }>().add('foo', ({ bar }) => new Foo('foo', bar));
+
+    const container = DIContainer.compose(bars, foos);
+
+    expectTypeOf(container.bar).toEqualTypeOf<Bar>();
+    expectTypeOf(container.foo).toEqualTypeOf<Foo>();
+  });
+
   test('extend function', () => {
     const containerA = () => {
       return new DIContainer().add('a', () => '1').add('bar', () => new Bar());

--- a/src/__tests__/__typetests__/testTypes.test-d.ts
+++ b/src/__tests__/__typetests__/testTypes.test-d.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line canonical/filename-match-regex
 import { DIContainer } from '../../DIContainer.js';
+import { type SealedContainer } from '../../types.js';
 import { Bar, Foo } from '../__helpers__/fakeClasses.js';
 import { describe, expectTypeOf, test } from 'vitest';
 
@@ -91,6 +92,41 @@ describe('DIContainer typescript type resolution', () => {
 
     expectTypeOf(container.bar).toEqualTypeOf<Bar>();
     expectTypeOf(container.foo).toEqualTypeOf<Foo>();
+  });
+
+  test('sealed container keeps the exact dependency types', () => {
+    const container = new DIContainer()
+      .add('key1', () => 'string')
+      .add('key2', () => 123)
+      .add('bar', () => new Bar());
+
+    type AppContainer = SealedContainer<typeof container>;
+    const sealed = container as AppContainer;
+
+    expectTypeOf(sealed.key1).toEqualTypeOf<string>();
+    expectTypeOf(sealed.key2).toEqualTypeOf<number>();
+    expectTypeOf(sealed.bar).toEqualTypeOf<Bar>();
+    expectTypeOf(sealed.get('key2')).toEqualTypeOf<number>();
+  });
+
+  test('sealed container stays chainable', () => {
+    const built = new DIContainer().add('a', () => '1').add('bar', () => new Bar());
+    const sealed = built as SealedContainer<typeof built>;
+
+    const container = sealed.add('foo', ({ a, bar }) => new Foo(a, bar));
+
+    expectTypeOf(container.foo).toEqualTypeOf<Foo>();
+  });
+
+  test('sealed container works for a composed container', () => {
+    const bars = new DIContainer().add('bar', () => new Bar());
+    const strings = new DIContainer().add('a', () => 'string');
+    const composed = DIContainer.compose(bars, strings);
+
+    const sealed = composed as SealedContainer<typeof composed>;
+
+    expectTypeOf(sealed.a).toEqualTypeOf<string>();
+    expectTypeOf(sealed.bar).toEqualTypeOf<Bar>();
   });
 
   test('extend function', () => {

--- a/src/__tests__/compose.test.ts
+++ b/src/__tests__/compose.test.ts
@@ -1,0 +1,89 @@
+import { DIContainer } from '../DIContainer.js';
+import { Bar, Buzz, Foo } from './__helpers__/fakeClasses.js';
+import { describe, expect, test, vi } from 'vitest';
+
+describe('DIContainer.compose', () => {
+  test('composes independently built containers', () => {
+    const repositories = new DIContainer().add('a', () => '1');
+    const services = new DIContainer().add('bar', () => new Bar());
+
+    const container = DIContainer.compose(repositories, services);
+
+    expect(container.a).toEqual('1');
+    expect(container.bar).toBeInstanceOf(Bar);
+  });
+
+  test('resolves dependencies across composed containers', () => {
+    const bars = new DIContainer().add('bar', () => new Bar());
+    // a module declares what it expects the composed container to provide
+    const foos = new DIContainer<{ bar: Bar }>().add('foo', ({ bar }) => new Foo('foo', bar));
+
+    const container = DIContainer.compose(bars, foos);
+
+    expect(container.foo).toBeInstanceOf(Foo);
+    expect(container.foo.bar).toBe(container.bar);
+  });
+
+  test('returns a new container and leaves the composed ones untouched', () => {
+    const containerA = new DIContainer().add('a', () => '1');
+    const containerB = new DIContainer().add('b', () => '2');
+
+    const container = DIContainer.compose(containerA, containerB);
+
+    expect(container).not.toBe(containerA);
+    expect(container).not.toBe(containerB);
+    expect(containerA.has('b')).toBe(false);
+    expect(containerB.has('a')).toBe(false);
+  });
+
+  test('last container wins when a name is defined twice', () => {
+    const containerA = new DIContainer().add('a', () => '1');
+    const containerB = new DIContainer().add('a', () => '2');
+
+    expect(DIContainer.compose(containerA, containerB).get('a')).toEqual('2');
+  });
+
+  test('composes no containers at all', () => {
+    expect(DIContainer.compose().has('a')).toBe(false);
+  });
+
+  test('composes a single container', () => {
+    const containerA = new DIContainer().add('a', () => '1');
+
+    expect(DIContainer.compose(containerA).a).toEqual('1');
+  });
+
+  test('accepts a container that has no resolvers yet', () => {
+    const containerA = new DIContainer().add('a', () => '1');
+
+    expect(DIContainer.compose(new DIContainer(), containerA).a).toEqual('1');
+  });
+
+  test('keeps resolution lazy and cached', () => {
+    const factory = vi.fn(() => new Buzz('buzz'));
+
+    const container = DIContainer.compose(new DIContainer().add('buzz', factory));
+    expect(factory).not.toHaveBeenCalled();
+
+    expect(container.buzz).toBe(container.buzz);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  test('carries over already resolved dependencies', () => {
+    const containerA = new DIContainer().add('buzz', () => new Buzz('buzz'));
+    containerA.buzz.name = 'buzz2';
+
+    const container = DIContainer.compose(containerA);
+
+    expect(container.buzz.name).toEqual('buzz2');
+  });
+
+  test('composed container can be extended further', () => {
+    const bars = new DIContainer().add('bar', () => new Bar());
+
+    const container = DIContainer.compose(bars).add('foo', ({ bar }) => new Foo('foo', bar));
+
+    expect(container.foo).toBeInstanceOf(Foo);
+    expect(container.foo.bar).toBeInstanceOf(Bar);
+  });
+});

--- a/src/__tests__/compose.test.ts
+++ b/src/__tests__/compose.test.ts
@@ -43,6 +43,26 @@ describe('DIContainer.compose', () => {
     expect(DIContainer.compose(containerA, containerB).get('a')).toEqual('2');
   });
 
+  test('an overriding container replaces a value the earlier one had already resolved', () => {
+    const containerA = new DIContainer().add('a', () => 'from A');
+    // resolve it first, so the earlier container holds a cached value
+    expect(containerA.a).toEqual('from A');
+
+    const containerB = new DIContainer().add('a', () => 'from B');
+
+    expect(DIContainer.compose(containerA, containerB).a).toEqual('from B');
+  });
+
+  test('an override keeps the later container own resolved value', () => {
+    const containerA = new DIContainer().add('buzz', () => new Buzz('from A'));
+    expect(containerA.buzz.name).toEqual('from A');
+
+    const containerB = new DIContainer().add('buzz', () => new Buzz('from B'));
+    containerB.buzz.name = 'resolved in B';
+
+    expect(DIContainer.compose(containerA, containerB).buzz.name).toEqual('resolved in B');
+  });
+
   test('composes no containers at all', () => {
     expect(DIContainer.compose().has('a')).toBe(false);
   });

--- a/src/__tests__/merge.test.ts
+++ b/src/__tests__/merge.test.ts
@@ -34,6 +34,24 @@ describe('DIContainer merge containers', () => {
     expect(finalContainer.a).toEqual('2');
   });
 
+  test('merge several containers in a single call', () => {
+    const containerA = new DIContainer().add('a', () => '1');
+    const containerB = new DIContainer().add('b', () => 'b');
+    const containerC = new DIContainer().add('buzz', () => new Buzz('buzz'));
+
+    const finalContainer = containerA.merge(containerB, containerC);
+
+    expect(finalContainer.a).toEqual('1');
+    expect(finalContainer.b).toEqual('b');
+    expect(finalContainer.buzz.name).toEqual('buzz');
+  });
+
+  test('merge without arguments keeps the container untouched', () => {
+    const containerA = new DIContainer().add('a', () => '1');
+
+    expect(containerA.merge().a).toEqual('1');
+  });
+
   test('resolved properties only once', () => {
     const containerA = new DIContainer().add('buzz', () => new Buzz('buzz'));
     const buzzInstance = containerA.buzz;

--- a/src/__tests__/merge.test.ts
+++ b/src/__tests__/merge.test.ts
@@ -52,6 +52,16 @@ describe('DIContainer merge containers', () => {
     expect(containerA.merge().a).toEqual('1');
   });
 
+  test('merging an override evicts the value the replaced resolver produced', () => {
+    const containerA = new DIContainer().add('a', () => '1');
+    // resolve before merging, so a stale cached value could survive its own resolver
+    expect(containerA.a).toEqual('1');
+
+    const containerB = new DIContainer().add('a', () => '2');
+
+    expect(containerA.merge(containerB).a).toEqual('2');
+  });
+
   test('resolved properties only once', () => {
     const containerA = new DIContainer().add('buzz', () => new Buzz('buzz'));
     const buzzInstance = containerA.buzz;

--- a/src/__tests__/reservedNames.test.ts
+++ b/src/__tests__/reservedNames.test.ts
@@ -1,0 +1,44 @@
+import { DIContainer } from '../DIContainer.js';
+import { ForbiddenNameError } from '../errors.js';
+import { describe, expect, test } from 'vitest';
+
+// Members that exist on the prototype but are not public API. A dependency may safely take
+// these names because nothing outside the class calls them through the instance.
+const nonPublicMembers = new Set([
+  'addContainerProperty',
+  'constructor',
+  'setResolvers',
+  'setValue',
+]);
+
+describe('reserved dependency names', () => {
+  // The guard is a hand-maintained Set, and a public method missing from it is not a compile
+  // error anywhere — `export` was absent until a dependency of that name was found to break
+  // every merge. This fails when a new public method is added without reserving its name.
+  test('every public instance method is reserved', () => {
+    const publicMethods = Object.getOwnPropertyNames(DIContainer.prototype).filter(
+      (name) => !nonPublicMembers.has(name),
+    );
+
+    expect(publicMethods.length).toBeGreaterThan(0);
+
+    for (const name of publicMethods) {
+      expect(() => new DIContainer().add(name as 'notAMethod', () => 1)).toThrow(
+        ForbiddenNameError,
+      );
+    }
+  });
+
+  test('a dependency cannot shadow export and break merge', () => {
+    expect(() => new DIContainer().add('export' as 'notAMethod', () => 1)).toThrow(
+      ForbiddenNameError,
+    );
+  });
+
+  test('static compose is not reserved — statics never shadow an instance property', () => {
+    const container = new DIContainer().add('compose', () => 'a value');
+
+    expect(container.compose).toEqual('a value');
+    expect(DIContainer.compose(container).compose).toEqual('a value');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { DIContainer } from './DIContainer.js';
-export { type IDIContainer } from './types.js';
+export { type IDIContainer, type ResolversOf, type SealedContainer } from './types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,24 @@ export type Resolvers<CR extends ResolvedDependencies> = {
 export type ResolversOf<C> =
   C extends DIContainer<infer R> ? R : C extends IDIContainer<infer R> ? R : never;
 
+/**
+ * Gives a built container a name that survives into hovers and error messages.
+ *
+ * `typeof container` and `ReturnType<typeof configureDI>` both resolve to a type
+ * that already carries its own name, so TypeScript prints the whole resolver
+ * intersection instead of the alias — unreadable once a container has more than a
+ * handful of dependencies. Wrapping the container in this helper produces a fresh
+ * alias, so diagnostics print `AppContainer` rather than
+ * `IDIContainer<{ a: … } & { b: … } & …>`.
+ *
+ * export type AppContainer = SealedContainer<typeof container>;
+ *
+ * This is an ergonomic wrapper, not a performance one: resolving a container type
+ * in a consuming file is already cheap, and naming it costs marginally more.
+ * The dependency types themselves are unchanged.
+ */
+export type SealedContainer<C> = IDIContainer<ResolversOf<C>>;
+
 export type StringLiteral<T> = T extends string ? (string extends T ? never : T) : never;
 
 export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,16 +2,17 @@ import { type DIContainer } from './DIContainer.js';
 
 export type DenyInputKeys<T, Disallowed> = T & (T extends Disallowed ? never : T);
 
-export type Factory<ContainerResolvers extends ResolvedDependencies> = (
-  resolvers: ContainerResolvers,
-) => ResolvedDependencyValue;
+export type Factory<
+  ContainerResolvers extends ResolvedDependencies,
+  Value = ResolvedDependencyValue,
+> = (resolvers: ContainerResolvers) => Value;
 
 export type IDIContainer<ContainerResolvers extends ResolvedDependencies = {}> =
   ContainerResolvers & {
-    add: <N extends string, R extends Factory<ContainerResolvers>>(
+    add: <N extends string, V>(
       name: StringLiteral<DenyInputKeys<N, keyof ContainerResolvers>>,
-      resolver: R,
-    ) => IDIContainer<ContainerResolvers & { [n in N]: ReturnType<R> }>;
+      resolver: Factory<ContainerResolvers, V>,
+    ) => IDIContainer<ContainerResolvers & { [n in N]: V }>;
     clone: () => IDIContainer<ContainerResolvers>;
     extend: <E extends (container: IDIContainer<ContainerResolvers>) => IDIContainer>(
       f: E,
@@ -22,12 +23,12 @@ export type IDIContainer<ContainerResolvers extends ResolvedDependencies = {}> =
     merge: <OtherContainerResolvers extends ResolvedDependencies>(
       container: DIContainer<OtherContainerResolvers> | IDIContainer<OtherContainerResolvers>,
     ) => IDIContainer<ContainerResolvers & OtherContainerResolvers>;
-    update: <N extends keyof ContainerResolvers, R extends Factory<ContainerResolvers>>(
+    update: <N extends keyof ContainerResolvers, V>(
       name: StringLiteral<N>,
-      resolver: R,
+      resolver: Factory<ContainerResolvers, V>,
     ) => IDIContainer<
       {
-        [n in N]: ReturnType<R>;
+        [n in N]: V;
       } & { [P in Exclude<keyof ContainerResolvers, N>]: ContainerResolvers[P] }
     >;
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,13 @@
 import { type DIContainer } from './DIContainer.js';
 
+/**
+ * Anything that can be composed/merged: a raw container instance or one that has
+ * already been widened by `add` (which returns `IDIContainer`).
+ */
+export type ContainerLike<R extends ResolvedDependencies = ResolvedDependencies> =
+  | DIContainer<R>
+  | IDIContainer<R>;
+
 export type DenyInputKeys<T, Disallowed> = T & (T extends Disallowed ? never : T);
 
 export type Factory<
@@ -20,9 +28,9 @@ export type IDIContainer<ContainerResolvers extends ResolvedDependencies = {}> =
     get: <Name extends keyof ContainerResolvers>(dependencyName: Name) => ContainerResolvers[Name];
     has: (name: string) => boolean;
     hasResolvedDependency: (name: string) => boolean;
-    merge: <OtherContainerResolvers extends ResolvedDependencies>(
-      container: DIContainer<OtherContainerResolvers> | IDIContainer<OtherContainerResolvers>,
-    ) => IDIContainer<ContainerResolvers & OtherContainerResolvers>;
+    merge: <T extends readonly ContainerLike[]>(
+      ...containers: T
+    ) => IDIContainer<ContainerResolvers & MergedResolvers<T>>;
     update: <N extends keyof ContainerResolvers, V>(
       name: StringLiteral<N>,
       resolver: Factory<ContainerResolvers, V>,
@@ -32,6 +40,20 @@ export type IDIContainer<ContainerResolvers extends ResolvedDependencies = {}> =
       } & { [P in Exclude<keyof ContainerResolvers, N>]: ContainerResolvers[P] }
     >;
   };
+
+/**
+ * Collapses the resolver maps of a tuple of containers into a single map.
+ *
+ * Uses a union-to-intersection fold rather than a recursive tuple walk: a
+ * recursive fold trips TypeScript's instantiation depth limiter (TS2589) once a
+ * few dozen containers are combined, which silently degrades inference.
+ */
+export type MergedResolvers<T extends readonly unknown[]> =
+  UnionToIntersection<ResolversOf<T[number]>> extends infer Merged
+    ? Merged extends ResolvedDependencies
+      ? Merged
+      : {}
+    : {};
 
 export type ResolvedDependencies = {
   [k: string]: ResolvedDependencyValue;
@@ -44,4 +66,17 @@ export type Resolvers<CR extends ResolvedDependencies> = {
   [k in keyof CR]?: Factory<CR>;
 };
 
+/**
+ * Extracts the resolver map from a container type. The class branch has to come
+ * first: a `DIContainer` instance also structurally matches `IDIContainer`.
+ */
+export type ResolversOf<C> =
+  C extends DIContainer<infer R> ? R : C extends IDIContainer<infer R> ? R : never;
+
 export type StringLiteral<T> = T extends string ? (string extends T ? never : T) : never;
+
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never;


### PR DESCRIPTION
## Why

Wiring a large graph as one fluent `.add()` chain costs **O(N²)** to type-check — the container type *is* the resolver map, re-embedded at every link. At 1600 dependencies that is 90 seconds and 7.8M type instantiations. This branch makes the graph composable instead, and adds a CI gate so the win cannot silently regress.

Everything here was measured with `tsc --extendedDiagnostics` (instantiation counts are deterministic; wall clock is not). A production app with ~340 dependencies integrated the branch mid-review and its numbers corrected two of my conclusions — noted below.

## What changed

**API (additive, backward compatible)**

- `DIContainer.compose(...containers)` — static; combines independently built containers into a **new** container, inputs untouched.
- `merge(...containers)` — now variadic. Single-argument calls infer exactly as before.
- `SealedContainer<C>` and `ResolversOf<C>` exported — give a built container a name that survives into hovers and errors.
- `add`/`update` infer the value directly instead of `R extends Factory<CR>` + `ReturnType<R>`. One generic instead of two.

**Results**

| Layout (TS 7, real source) | Instantiations | Check time |
|---|---:|---:|
| one chain of 1600 | 7,815,223 | 90.2s |
| 80 modules of 20 → `compose` | 361,552 | 0.9s |

~22× fewer instantiations, ~100× faster, and the gap widens with N. Verified from a real consumer installing the packed tarball: 12.42s → 0.46s at 800 dependencies, plus a free ~24% on an unchanged flat chain just from the `add`/`update` cleanup.

**New CI job: `types-perf`** (`pnpm bench:types`, in the required `CI` check)

Four scenarios gated on instantiation budgets. This is not redundant with the type tests — those assert inference at three or four dependencies, and **both** known failure modes pass the full 82-test suite untouched:

| Regression reintroduced | `pnpm test` | `pnpm bench:types` |
|---|---|---|
| recursive tuple fold in `MergedResolvers` | 82 passed ✅ | FAILED — TS2589 + `never` ✗ |
| `Simplify` flatten on the `add` accumulator | 82 passed ✅ | FAILED — 507× TS2589 ✗ |
| eager `Add<>` mapped type for `add`'s return | 82 passed ✅ | FAILED — TS2589 at 64 and 200 ✗ |

Every fixture also asserts exact types, so the gate cannot be satisfied by degrading inference to `any` — which would *lower* the count.

**Docs**

- `docs/ai-agent-guide.md` — integration guide for AI agents, shipped in the package so it is readable from `node_modules`. Every example compiles against `dist/`; the "this is rejected" cases are pinned with `@ts-expect-error`.
- `docs/type-performance-plan.md` — full measured analysis, including what does **not** help.
- `docs/type-benchmarks.md` — how to read the gate and why the metric is instantiations.
- Fixed a real bug in `docs/async_factory_resolver.md`: it registered a value where `add` takes a factory, which neither compiles nor runs.

## Two things the field report corrected

1. **Isolation, not splitting.** My synthetic benchmark suggested splitting into `.extend()` modules scales. In the real app, splitting while threading the accumulated container measured *worse* than the flat chain (3.41M → 3.48M). The win comes from checking a module against a small declared surface: composed leaves with explicit consumed-type seeds checked ~13× faster (924.8ms → 68.7ms). Docs now say isolation.
2. **Module size is not the lever.** I had written "aim for 20–40 per module". The same 64 dependencies on a 300-key seed cost 38.1K instantiations as one module and 36.3K split four ways — under 5%. ~64 is now documented as a comfortable ceiling with size framed as a readability choice, and `module-seeded-64` guards that shape.

## Review notes

- **No source change was needed for the `Add<>` concern** — we already ship the lazy `&`; verified clean at 64 and 100 adds over 300- and 500-key seeds on both TS 7.0.2 and TS 5.9.3.
- Two type-level choices are load-bearing and covered by tests: `MergedResolvers` uses union-to-intersection (a recursive fold trips TS2589 at ~50 containers), and `ResolversOf` checks the class branch before the `IDIContainer` branch (otherwise a raw `new DIContainer()` contributes `never`).
- **Item 4 shipped against its own premise.** Sealing was scoped as a consumer performance fix; measurement showed consumers are already cheap and sealing costs ~3% *more*, so it ships as a readability helper only. Recorded in the plan doc so it is not re-attempted.
- `merge` still mutates (unchanged behaviour); `compose` and `clone` are the non-mutating options.
- **Version:** this adds public API, so it wants a **minor** bump before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
