### PR TITLE
perf: linear wiring and faster cached resolution, with a benchmark suite to prove it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Use **pnpm** (pinned via `packageManager`; do not use npm/yarn).
 | Lint (check)         | `pnpm lint`                                           |
 | Format + autofix     | `pnpm format`                                         |
 | Type-cost budgets    | `pnpm bench:types`                                    |
+| Runtime benchmarks   | `pnpm bench` (`vitest bench --run`)                   |
 
 `pnpm lint` runs `oxfmt --check` then `oxlint --type-aware --type-check`; `pnpm format` runs the same two tools in write/`--fix` mode.
 
@@ -42,7 +43,9 @@ src/
   __tests__/
     *.test.ts                     # runtime tests (vitest)
     __typetests__/*.test-d.ts     # TYPE tests (vitest expectTypeOf, needs --typecheck)
+    __benchmarks__/*.bench.ts     # runtime benchmarks (vitest bench, needs `pnpm bench`)
     __helpers__/fakeClasses.ts    # shared test fixtures
+    __helpers__/syntheticGraph.ts # generated containers for the benchmarks
 ```
 
 ## Architecture
@@ -83,6 +86,10 @@ Adding a public **instance** method to the class means adding its name to that `
 Factories receive `this.context`, a `Proxy` built in the constructor that forwards property reads back to the container — that is what makes `.add('foo', ({ a, bar }) => …)` destructuring resolve dependencies lazily at call time rather than at registration time.
 
 `update()` must delete the cached value for the name it replaces; without that, a container that had already resolved the dependency keeps returning the stale instance. This was a real bug fixed in 3.1.0.
+
+## Runtime benchmarks
+
+`pnpm bench` runs `src/__tests__/__benchmarks__/*.bench.ts` through `vitest bench`, pricing the runtime claims above: cache hits are flat, `add` is O(N²), `compose` adds nothing. **Read each group as ratios between its own rows** — wall clock does not transfer between machines, so there are no budgets and no CI job (`docs/type-benchmarks.md` explains why).
 
 ## Conventions & gotchas (read before editing)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,8 @@ Adding a public **instance** method to the class means adding its name to that `
 
 `clone()` works through `ClonedDiContainer`, a non-exported subclass at the bottom of `DIContainer.ts`. It exists purely to provide a constructor that seeds resolvers, because the public `DIContainer` constructor deliberately takes no arguments. `setResolvers` is `protected` for the same reason and throws if resolvers already exist.
 
+**No two containers may share a resolver map.** `add` and `merge` write into `this.resolvers` in place — that is what keeps a chain linear instead of quadratic — so `setResolvers` has to copy what `clone()` hands it. Adopting the source's map instead would leak every later registration back into it in both directions. Three tests in `clone.test.ts` pin this; they are the reason the in-place writes are safe.
+
 ### Resolution: lazy, cached, via two access paths
 
 `get(name)` and property access (`container.name`) reach the same cache. Property access is wired by `addContainerProperty`, which `Object.defineProperty`s a getter delegating to `get()` as each resolver is registered.
@@ -89,7 +91,9 @@ Factories receive `this.context`, a `Proxy` built in the constructor that forwar
 
 ## Runtime benchmarks
 
-`pnpm bench` runs `src/__tests__/__benchmarks__/*.bench.ts` through `vitest bench`, pricing the runtime claims above: cache hits are flat, `add` is O(N²), `compose` adds nothing. **Read each group as ratios between its own rows** — wall clock does not transfer between machines, so there are no budgets and no CI job (`docs/type-benchmarks.md` explains why).
+`pnpm bench` runs `src/__tests__/__benchmarks__/*.bench.ts` through `vitest bench`, pricing the runtime claims above: cache hits are flat in container size, wiring is linear, `compose` adds nothing. **Read each group as ratios between its own rows** — wall clock does not transfer between machines, so there are no budgets and no CI job (`docs/type-benchmarks.md` explains why).
+
+**A benchmark body must not repeat one loop-invariant call.** Resolving a fixed name in a batch lets V8 hoist the call clean out of the loop, so the row measures the optimiser instead of the container — that artefact reported a 2.7x speedup here as a 1.6x regression, in both directions, reproducibly. Vary the name per iteration, as `resolve.bench.ts` does.
 
 ## Conventions & gotchas (read before editing)
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     }
   },
   "scripts": {
+    "bench": "vitest bench --run",
     "bench:types": "node scripts/bench-types.mjs",
     "build": "tsc",
     "format": "oxfmt --threads=1 && oxlint --type-aware --type-check --quiet --fix",

--- a/src/DIContainer.ts
+++ b/src/DIContainer.ts
@@ -48,9 +48,9 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
   public constructor() {
     this.context = new Proxy(this, {
       get(target, property) {
-        const propertyName = property.toString() as keyof DIContainer<ContainerResolvers>;
-
-        return target[propertyName];
+        // Indexing with the key as given: `toString()` here cost a call on every dependency a
+        // factory destructures, and turned a symbol lookup into a miss under its description.
+        return target[property as keyof DIContainer<ContainerResolvers>];
       },
     }) as unknown as ContainerResolvers;
   }
@@ -176,8 +176,9 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
   public get<Name extends keyof ContainerResolvers>(
     dependencyName: Name,
   ): ContainerResolvers[Name] {
-    if (this.resolvedDependencies[dependencyName] !== undefined) {
-      return this.resolvedDependencies[dependencyName];
+    const resolved = this.resolvedDependencies[dependencyName];
+    if (resolved !== undefined) {
+      return resolved;
     }
 
     const resolver = this.resolvers[dependencyName];
@@ -185,9 +186,10 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
       throw new DependencyIsMissingError(dependencyName as string);
     }
 
-    this.resolvedDependencies[dependencyName] = resolver(this.context);
+    const value = resolver(this.context);
+    this.resolvedDependencies[dependencyName] = value;
 
-    return this.resolvedDependencies[dependencyName];
+    return value;
   }
 
   /**
@@ -224,36 +226,45 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
   public merge<T extends readonly ContainerLike[]>(
     ...containers: T
   ): IDIContainer<ContainerResolvers & MergedResolvers<T>> {
+    const ownResolvers = this.resolvers as Record<string, Factory<ContainerResolvers>>;
+    const ownResolvedDependencies = this.resolvedDependencies as Record<
+      string,
+      ResolvedDependencyValue
+    >;
+
     for (const otherContainer of containers) {
       const { resolvedDependencies: newResolvedDependencies, resolvers: newResolvers } = (
         otherContainer as DIContainer<ResolvedDependencies>
       ).export();
 
-      // A replaced resolver must not keep the value the previous one produced — the same
-      // eviction `update()` performs. Only the overriding container's own cache may survive,
-      // so a name it re-registers without having resolved yet has to lose the old value;
-      // otherwise `merge`/`compose` return the earlier container's instance from a resolver
-      // that no longer exists, silently contradicting last-writer-wins.
       for (const name of Object.keys(newResolvers)) {
-        if (!Object.hasOwn(newResolvedDependencies, name)) {
+        // A replaced resolver must not keep the value the previous one produced — the same
+        // eviction `update()` performs. Only the overriding container's own cache may survive,
+        // so a name it re-registers without having resolved yet has to lose the old value;
+        // otherwise `merge`/`compose` return the earlier container's instance from a resolver
+        // that no longer exists, silently contradicting last-writer-wins.
+        //
+        // Our own cache is tested first so that merging into a container that has resolved
+        // nothing — the `compose` case — issues no deletes at all.
+        if (
+          Object.hasOwn(this.resolvedDependencies, name) &&
+          !Object.hasOwn(newResolvedDependencies, name)
+        ) {
           // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
           delete this.resolvedDependencies[name as keyof ContainerResolvers];
         }
+
+        // Only the incoming names can be new, so this replaces a rescan of the whole merged map.
+        this.addContainerProperty(name);
+
+        // Writing into the map rather than rebuilding it per container is what keeps
+        // `compose(...modules)` linear in total dependencies instead of quadratic.
+        ownResolvers[name] = (newResolvers as Record<string, Factory<ContainerResolvers>>)[name];
       }
 
-      this.resolvers = {
-        ...this.resolvers,
-        ...newResolvers,
-      };
-
-      this.resolvedDependencies = {
-        ...this.resolvedDependencies,
-        ...newResolvedDependencies,
-      };
-    }
-
-    for (const property of Object.keys(this.resolvers)) {
-      this.addContainerProperty(property);
+      for (const name of Object.keys(newResolvedDependencies)) {
+        ownResolvedDependencies[name] = newResolvedDependencies[name];
+      }
     }
 
     return this as unknown as IDIContainer<ContainerResolvers & MergedResolvers<T>>;
@@ -311,39 +322,47 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
       throw new Error('Cannot set resolved dependencies after resolvers are defined');
     }
 
-    // @ts-expect-error - we are setting resolvers
-    this.resolvers = resolvers;
-    // @ts-expect-error - we are setting resolvedDependencies
-    this.resolvedDependencies = {
-      ...resolvedDependencies,
-    };
-    for (const property of Object.keys(this.resolvers)) {
-      this.addContainerProperty(property);
+    // Both maps are copied, not adopted. `add` and `merge` write into them in place, so a clone
+    // that kept its source's map would leak every later registration back into it.
+    //
+    // Entry by entry rather than by spread: these maps are built a key at a time, which leaves
+    // them in V8's dictionary mode, and spreading one of those costs over twice what the loop does.
+    const ownResolvers = this.resolvers as Record<string, Factory<ContainerResolvers>>;
+    const source = resolvers as unknown as Record<string, Factory<ContainerResolvers>>;
+    for (const name of Object.keys(source)) {
+      ownResolvers[name] = source[name];
+      this.addContainerProperty(name);
+    }
+
+    const ownResolvedDependencies = this.resolvedDependencies as Record<
+      string,
+      ResolvedDependencyValue
+    >;
+    for (const name of Object.keys(resolvedDependencies)) {
+      ownResolvedDependencies[name] = resolvedDependencies[name];
     }
   }
 
-  private addContainerProperty(name: string) {
-    // eslint-disable-next-line unicorn/no-this-assignment, @typescript-eslint/no-this-alias, consistent-this
-    let updatedObject = this;
-    if (!Object.hasOwn(this, name)) {
-      updatedObject = Object.defineProperty(this, name, {
-        get() {
-          return this.get(name);
-        },
-      });
+  private addContainerProperty(name: string): void {
+    if (Object.hasOwn(this, name)) {
+      return;
     }
 
-    return updatedObject;
+    Object.defineProperty(this, name, {
+      get() {
+        return this.get(name);
+      },
+    });
   }
 
   /**
    * Sets value to the container
    */
   private setValue(name: string, resolver: Factory<ContainerResolvers>): void {
-    this.resolvers = {
-      ...this.resolvers,
-      [name]: resolver,
-    };
+    // Writing into the map rather than rebuilding it is what makes a chain of `add` calls linear
+    // instead of quadratic. It is safe only because no two containers ever share a resolver map —
+    // `setResolvers` copies what `clone()` hands it, which `clone.test.ts` pins.
+    (this.resolvers as Record<string, Factory<ContainerResolvers>>)[name] = resolver;
 
     this.addContainerProperty(name);
   }

--- a/src/__tests__/__benchmarks__/resolve.bench.ts
+++ b/src/__tests__/__benchmarks__/resolve.bench.ts
@@ -1,0 +1,65 @@
+// What a container costs per use: repeated cache hits, then the one-time factory + `Proxy` cost.
+import { DIContainer } from '../../DIContainer.js';
+import { Bar, Foo } from '../__helpers__/fakeClasses.js';
+import {
+  buildIndependentChain,
+  buildLinkedChain,
+  resolveAll,
+  sink,
+} from '../__helpers__/syntheticGraph.js';
+import { bench, describe } from 'vitest';
+
+// A cache hit is below tinybench's timer overhead, so rows batch; `hz` is batches/sec.
+const BATCH_SIZE = 1_000;
+
+const CHAIN_SIZE = 100;
+
+const LAST_KEY = `k${CHAIN_SIZE - 1}`;
+
+describe(`cached resolution (×${BATCH_SIZE.toLocaleString()} per sample)`, () => {
+  const container = new DIContainer()
+    .add('name', () => 'hello')
+    .add('bar', () => new Bar())
+    .add('foo', ({ bar, name }) => new Foo(name, bar));
+
+  const large = buildLinkedChain(CHAIN_SIZE);
+
+  // Warm the cache; first calls belong to the group below.
+  container.get('foo');
+  resolveAll(large, CHAIN_SIZE);
+
+  bench('get()', () => {
+    for (let index = 0; index < BATCH_SIZE; index++) {
+      sink.value = container.get('foo');
+    }
+  });
+
+  // Should track `get()`; a gap means the getter stopped forwarding.
+  bench('property access', () => {
+    for (let index = 0; index < BATCH_SIZE; index++) {
+      sink.value = container.foo;
+    }
+  });
+
+  bench(`get() — ${CHAIN_SIZE}-dependency container`, () => {
+    for (let index = 0; index < BATCH_SIZE; index++) {
+      sink.value = large.get(LAST_KEY);
+    }
+  });
+});
+
+describe(`first resolution of ${CHAIN_SIZE} dependencies`, () => {
+  // `add` mutates and values stay cached, so each sample wires its own. Subtract to price resolution.
+  bench('wire only (baseline)', () => {
+    sink.value = buildIndependentChain(CHAIN_SIZE);
+  });
+
+  bench('wire + resolve — factories take no dependencies', () => {
+    resolveAll(buildIndependentChain(CHAIN_SIZE), CHAIN_SIZE);
+  });
+
+  // Same graph, but factories destructure: the gap is the `Proxy` trap.
+  bench('wire + resolve — factories destructure from the context proxy', () => {
+    resolveAll(buildLinkedChain(CHAIN_SIZE), CHAIN_SIZE);
+  });
+});

--- a/src/__tests__/__benchmarks__/resolve.bench.ts
+++ b/src/__tests__/__benchmarks__/resolve.bench.ts
@@ -4,6 +4,7 @@ import { Bar, Foo } from '../__helpers__/fakeClasses.js';
 import {
   buildIndependentChain,
   buildLinkedChain,
+  keysOf,
   resolveAll,
   sink,
 } from '../__helpers__/syntheticGraph.js';
@@ -14,7 +15,7 @@ const BATCH_SIZE = 1_000;
 
 const CHAIN_SIZE = 100;
 
-const LAST_KEY = `k${CHAIN_SIZE - 1}`;
+const SMALL_KEYS = ['name', 'bar', 'foo'] as const;
 
 describe(`cached resolution (×${BATCH_SIZE.toLocaleString()} per sample)`, () => {
   const container = new DIContainer()
@@ -24,26 +25,30 @@ describe(`cached resolution (×${BATCH_SIZE.toLocaleString()} per sample)`, () =
 
   const large = buildLinkedChain(CHAIN_SIZE);
 
+  const largeKeys = keysOf(CHAIN_SIZE);
+
   // Warm the cache; first calls belong to the group below.
   container.get('foo');
   resolveAll(large, CHAIN_SIZE);
 
+  // The name has to vary per iteration. Asking for one fixed key leaves the call loop-invariant,
+  // and V8 hoists it clean out of the batch — which made a 4x speedup read as a 1.6x regression.
   bench('get()', () => {
     for (let index = 0; index < BATCH_SIZE; index++) {
-      sink.value = container.get('foo');
+      sink.value = container.get(SMALL_KEYS[index % SMALL_KEYS.length]);
     }
   });
 
   // Should track `get()`; a gap means the getter stopped forwarding.
   bench('property access', () => {
     for (let index = 0; index < BATCH_SIZE; index++) {
-      sink.value = container.foo;
+      sink.value = container[SMALL_KEYS[index % SMALL_KEYS.length]];
     }
   });
 
   bench(`get() — ${CHAIN_SIZE}-dependency container`, () => {
     for (let index = 0; index < BATCH_SIZE; index++) {
-      sink.value = large.get(LAST_KEY);
+      sink.value = large.get(largeKeys[index % CHAIN_SIZE]);
     }
   });
 });

--- a/src/__tests__/__benchmarks__/wiring.bench.ts
+++ b/src/__tests__/__benchmarks__/wiring.bench.ts
@@ -1,0 +1,43 @@
+// What a container costs to build. `add` copies the resolver map per call, so a chain is O(N²) at
+// runtime too; the second group checks `compose` adds no runtime tax.
+import { DIContainer } from '../../DIContainer.js';
+import { buildIndependentChain, buildModules, sink } from '../__helpers__/syntheticGraph.js';
+import { bench, describe } from 'vitest';
+
+const CHAIN_SIZES = [50, 100, 200];
+
+const GRAPH_SIZE = 200;
+
+const MODULE_COUNT = 20;
+
+describe('add — a growing chain', () => {
+  // Doubling the size should roughly quadruple the time.
+  for (const size of CHAIN_SIZES) {
+    bench(`chain of ${size}`, () => {
+      sink.value = buildIndependentChain(size);
+    });
+  }
+});
+
+describe(`assembling ${GRAPH_SIZE} dependencies`, () => {
+  // `compose` and `clone` leave inputs untouched, so these survive reuse.
+  const modules = buildModules(GRAPH_SIZE, MODULE_COUNT);
+
+  const built = buildIndependentChain(GRAPH_SIZE);
+
+  bench('one add chain', () => {
+    sink.value = buildIndependentChain(GRAPH_SIZE);
+  });
+
+  bench(`${MODULE_COUNT} modules, built and composed`, () => {
+    sink.value = DIContainer.compose(...buildModules(GRAPH_SIZE, MODULE_COUNT));
+  });
+
+  bench(`${MODULE_COUNT} pre-built modules, composed`, () => {
+    sink.value = DIContainer.compose(...modules);
+  });
+
+  bench('clone a built container', () => {
+    sink.value = built.clone();
+  });
+});

--- a/src/__tests__/__helpers__/syntheticGraph.ts
+++ b/src/__tests__/__helpers__/syntheticGraph.ts
@@ -1,0 +1,72 @@
+import { DIContainer } from '../../DIContainer.js';
+import { type Factory, type IDIContainer, type ResolvedDependencies } from '../../types.js';
+
+/**
+ * Generated graphs cannot use `add`, which requires a string literal. Runtime cost ignores the
+ * static type, so the casts that buys stay in this file.
+ */
+export type SyntheticContainer = IDIContainer<ResolvedDependencies>;
+
+type Node = {
+  v: number;
+};
+
+/** Keeps results observable, so the optimiser cannot delete the measured call. */
+export const sink: { value: unknown } = { value: undefined };
+
+const emptyContainer = (): SyntheticContainer => new DIContainer() as unknown as SyntheticContainer;
+
+const addDynamic = (
+  container: SyntheticContainer,
+  name: string,
+  factory: Factory<ResolvedDependencies>,
+): SyntheticContainer => container.add(name as never, factory) as SyntheticContainer;
+
+export const buildIndependentChain = (size: number): SyntheticContainer => {
+  let container = emptyContainer();
+
+  for (let index = 0; index < size; index++) {
+    container = addDynamic(container, `k${index}`, () => ({ v: index }));
+  }
+
+  return container;
+};
+
+/** Same chain, each factory destructuring its predecessor — the shape that hits the proxy. */
+export const buildLinkedChain = (size: number): SyntheticContainer => {
+  let container = emptyContainer();
+
+  for (let index = 0; index < size; index++) {
+    const previous = `k${index - 1}`;
+
+    container =
+      index === 0
+        ? addDynamic(container, 'k0', () => ({ v: 0 }))
+        : addDynamic(container, `k${index}`, (dependencies) => ({
+            v: (dependencies[previous] as Node).v + 1,
+          }));
+  }
+
+  return container;
+};
+
+/** `size` must divide evenly. */
+export const buildModules = (size: number, moduleCount: number): SyntheticContainer[] => {
+  const perModule = size / moduleCount;
+
+  return Array.from({ length: moduleCount }, (_, module) => {
+    let container = emptyContainer();
+
+    for (let index = 0; index < perModule; index++) {
+      container = addDynamic(container, `k${module * perModule + index}`, () => ({ v: index }));
+    }
+
+    return container;
+  });
+};
+
+export const resolveAll = (container: SyntheticContainer, size: number): void => {
+  for (let index = 0; index < size; index++) {
+    sink.value = container.get(`k${index}`);
+  }
+};

--- a/src/__tests__/__helpers__/syntheticGraph.ts
+++ b/src/__tests__/__helpers__/syntheticGraph.ts
@@ -70,3 +70,6 @@ export const resolveAll = (container: SyntheticContainer, size: number): void =>
     sink.value = container.get(`k${index}`);
   }
 };
+
+export const keysOf = (size: number): string[] =>
+  Array.from({ length: size }, (_, index) => `k${index}`);

--- a/src/__tests__/clone.test.ts
+++ b/src/__tests__/clone.test.ts
@@ -14,6 +14,34 @@ describe('DIContainer merge containers', () => {
     expect(boundedContextB.buzz.name).toEqual('buzzB');
   });
 
+  // `add` and `merge` write into the resolver map in place, so a clone that adopted its source's
+  // map rather than copying it would leak every later registration in either direction. These
+  // three pin that; without the copy in `setResolvers` they fail.
+  test('adding to a clone leaves the original untouched', () => {
+    const baseContainer = new DIContainer().add('a', () => 'a');
+
+    baseContainer.clone().add('b', () => 'b');
+
+    expect(baseContainer.has('b')).toBe(false);
+  });
+
+  test('adding to the original leaves an existing clone untouched', () => {
+    const baseContainer = new DIContainer().add('a', () => 'a');
+    const cloned = baseContainer.clone();
+
+    baseContainer.add('b', () => 'b');
+
+    expect(cloned.has('b')).toBe(false);
+  });
+
+  test('merging into a clone leaves the original untouched', () => {
+    const baseContainer = new DIContainer().add('a', () => 'a');
+
+    baseContainer.clone().merge(new DIContainer().add('b', () => 'b'));
+
+    expect(baseContainer.has('b')).toBe(false);
+  });
+
   test('clone container after dependency resolution', () => {
     const baseContainer = new DIContainer().add('buzz', () => new Buzz('buzzA'));
     // resolve buzz dependency

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+// `tsc` compiles the tests and benchmarks along with the sources, so every file under `src/` has a
+// compiled twin under `dist/`. Vitest 4 dropped `**/dist/**` from its default excludes, which left
+// each suite running twice — the second time against whatever the last build emitted. That is
+// harmless when the two agree and quietly misleading when they do not: benchmark runs reported two
+// sets of numbers for the same name, and a stale `dist/` could pass a suite the sources fail.
+const EXCLUDE = ['**/node_modules/**', '**/dist/**'];
+
+export default defineConfig({
+  test: {
+    benchmark: {
+      exclude: EXCLUDE,
+    },
+    exclude: EXCLUDE,
+    typecheck: {
+      exclude: EXCLUDE,
+    },
+  },
+});


### PR DESCRIPTION
Adds a runtime benchmark suite, then uses it to make the container substantially faster. The two are in one PR because the second half is only trustworthy given the first — and because building the harness immediately exposed two ways it was lying.

## Results

Measured with `pnpm bench` (added here), before vs. after, on the same machine:

| benchmark | before | after | |
| --- | ---: | ---: | --- |
| `add` chain of 200 | 2,158 hz | 21,433 hz | **9.9× faster** |
| `add` chain of 100 | 9,062 hz | 47,210 hz | 5.2× |
| `compose` 20 pre-built modules | 13,859 hz | 32,547 hz | 2.4× |
| cached `get()` — 100 deps | 33,389 hz | 88,979 hz | **2.7× faster** |
| cached `get()` — 3 deps | 65,759 hz | 88,612 hz | 1.35× |
| property access | 43,629 hz | 55,076 hz | 1.26× |
| `clone` a 200-dep container | 43,794 hz | 34,561 hz | **0.79× — slower** |

## The main change

`add` rebuilt the entire resolver map on every call (`{ ...this.resolvers, [name]: resolver }`), making a chain O(N²) at runtime for the same reason it is O(N²) to type-check. `merge` did the same once per merged container. Both now write in place.

That is only safe because of an invariant the code did not previously enforce: **`clone()` handed the clone its source's actual map object**, and the two stayed independent only because every write happened to allocate a replacement. `setResolvers` now copies, and three new tests in `clone.test.ts` pin it in both directions — they fail without the copy.

Smaller wins, all measured:

- `get()` no longer reads the resolved-value cache twice. Worth roughly 2× on a large container, where the map is in V8's dictionary mode and each read is a hash lookup.
- The context `Proxy` no longer calls `.toString()` on every dependency a factory destructures. Symbols now pass through as symbols rather than being looked up under their description.
- The copies in `setResolvers` are entry-by-entry loops rather than spreads — measured 2.4× cheaper for a dictionary-mode map, which is what took `clone` from 0.39× back to 0.79×.

### The `clone` regression is deliberate

It is the irreducible cost of the extra map copy that makes in-place `add` safe: 59 µs → 29 µs to clone a 200-dependency container, a rare operation, in exchange for wins on `add` and `get`, which every consumer pays on every use. Flagging it rather than burying it.

## Two harness bugs found while building the benchmarks

Both were making the numbers lie, and the first predates this PR.

**1. Vitest was running every suite twice.** `tsc` compiles the tests alongside the sources, and Vitest 4 dropped `**/dist/**` from its default excludes — so each suite ran once from `src/` and again from whatever the last build emitted into `dist/`. That is why `pnpm test` reported 16 files for 8. It also means a stale `dist/` could pass a suite the sources fail. Fixed with a `vitest.config.ts`.

**2. The cached-resolution benchmarks were measuring V8's optimiser.** Resolving one fixed name in a batch leaves the call loop-invariant, and V8 hoists it clean out of the loop — in the old build but not the new one. That artefact reported the 2.7× `get()` speedup above as a *1.6× regression*, reproducibly, in both directions. The rows now vary the name per iteration.

The corrected direction was confirmed independently of Vitest, in isolated processes against both compiled builds: 25 ns → 6 ns per cached `get()` at 100 dependencies, stable across alternating runs.

## Notes for review

- No public API or type changes; `dist/` output is unchanged in shape.
- Zero runtime dependencies preserved; the benchmark suite is dev-only and excluded from the published package by the existing `files` rule.
- `pnpm build`, `pnpm test`, `pnpm lint` and `pnpm bench:types` all pass; type-instantiation budgets are unmoved.
- Benchmarks are deliberately **not** wired into CI — wall clock does not transfer between machines, which is the same reasoning `docs/type-benchmarks.md` already gives for gating the type budgets on instantiations instead of time.
