### PR TITLE
fix: stop export() handing out the live resolver maps, and guard the in-place writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,11 @@ Adding a public **instance** method to the class means adding its name to that `
 
 `clone()` works through `ClonedDiContainer`, a non-exported subclass at the bottom of `DIContainer.ts`. It exists purely to provide a constructor that seeds resolvers, because the public `DIContainer` constructor deliberately takes no arguments. `setResolvers` is `protected` for the same reason and throws if resolvers already exist.
 
-**No two containers may share a resolver map.** `add` and `merge` write into `this.resolvers` in place — that is what keeps a chain linear instead of quadratic — so `setResolvers` has to copy what `clone()` hands it. Adopting the source's map instead would leak every later registration back into it in both directions. Three tests in `clone.test.ts` pin this; they are the reason the in-place writes are safe.
+**No two containers may share a resolver map.** `add`, `update` and `merge` write into `this.resolvers` in place — that is what keeps a chain linear instead of quadratic — so `setResolvers` has to copy what `clone()` hands it. Adopting the source's map instead would leak every later registration back into it in both directions. Three tests in `clone.test.ts` pin this; they are the reason the in-place writes are safe.
+
+Those writes cost a chain of 1600 dependencies 196 ms before and 0.6 ms after, so **treat a rebuild of either map as a performance bug, not a style choice.** Wall clock can't guard that in CI, so `resolverMapOwnership.test.ts` asserts the maps keep their identity across `add`, `update`, `merge` and a cached `get` — the same invariant, stated deterministically. A `{ ...this.resolvers }` anywhere on those paths fails there.
+
+**`export()` is the one place that copies on purpose.** Before the in-place writes, `add` replaced `this.resolvers` outright, so what `export()` returned was a de-facto snapshot; handing out the live map now would let a caller watch the container change under them and mutate it by writing into what they were given. Nothing inside the class calls it — `clone()` and `merge()` read the protected maps directly, cross-instance — so no internal path pays for the copy. Note `export` is declared on the class but **not** on `IDIContainer`, so it is unreachable once a chain has widened the type; if that is ever fixed, fix it in both files.
 
 ### Resolution: lazy, cached, via two access paths
 

--- a/src/DIContainer.ts
+++ b/src/DIContainer.ts
@@ -17,9 +17,10 @@ import {
 
 // Every public *instance* member, because `addContainerProperty` defines dependencies as own
 // properties that would otherwise shadow the method of the same name. `export` belongs here even
-// though it is rarely used directly: `merge` calls it on the containers passed to it, so a
-// dependency named `export` turned any `merge`/`compose` involving that container into a
-// `TypeError`. Statics (`compose`) never live on the instance and are deliberately absent.
+// though it is rarely used directly: it once broke every `merge`/`compose` with a `TypeError`,
+// because `merge` called it on the containers passed to it. `merge` reads the protected maps
+// directly now, so only a consumer's own call is at stake — still public API, so still reserved.
+// Statics (`compose`) never live on the instance and are deliberately absent.
 // `src/__tests__/reservedNames.test.ts` fails if a new public method is not listed here.
 const containerMethods = new Set([
   'add',
@@ -125,18 +126,30 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
    * The cloned container is a new instance but retains all the original resolvers.
    */
   public clone(): DIContainer<ContainerResolvers> {
-    const { resolvedDependencies: newResolvedDependencies, resolvers: newResolvers } =
-      this.export();
+    // Handed the live maps on purpose — `setResolvers` is what copies them, and routing this
+    // through `export()` would only allocate a second copy to throw away.
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    const newContainer = new ClonedDiContainer(newResolvers, newResolvedDependencies);
+    const newContainer = new ClonedDiContainer(
+      this.resolvers,
+      this.resolvedDependencies as { [name in keyof ContainerResolvers]: ResolvedDependencyValue },
+    );
 
     return newContainer as DIContainer<ContainerResolvers>;
   }
 
+  /**
+   * Returns the container's resolvers and its already-resolved values.
+   *
+   * Both maps are copies. `add`, `update` and `merge` write into the internal maps in place, so
+   * handing out the live objects would let a caller both observe registrations made after the
+   * call and mutate the container by writing into what they were given. Nothing inside the class
+   * goes through here — `clone` and `merge` read the protected maps directly — so the copy is
+   * paid only by a consumer that asks for it.
+   */
   public export(): ResolvedDependencies {
     return {
-      resolvedDependencies: this.resolvedDependencies,
-      resolvers: this.resolvers,
+      resolvedDependencies: { ...this.resolvedDependencies },
+      resolvers: { ...this.resolvers },
     };
   }
 
@@ -233,9 +246,10 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
     >;
 
     for (const otherContainer of containers) {
-      const { resolvedDependencies: newResolvedDependencies, resolvers: newResolvers } = (
-        otherContainer as DIContainer<ResolvedDependencies>
-      ).export();
+      // The protected maps directly, not `export()`: that copies now, and every name is copied
+      // again into our own maps below — one throwaway map per merged container, for nothing.
+      const { resolvedDependencies: newResolvedDependencies, resolvers: newResolvers } =
+        otherContainer as DIContainer<ResolvedDependencies>;
 
       for (const name of Object.keys(newResolvers)) {
         // A replaced resolver must not keep the value the previous one produced — the same

--- a/src/__tests__/__benchmarks__/wiring.bench.ts
+++ b/src/__tests__/__benchmarks__/wiring.bench.ts
@@ -1,5 +1,6 @@
-// What a container costs to build. `add` copies the resolver map per call, so a chain is O(N²) at
-// runtime too; the second group checks `compose` adds no runtime tax.
+// What a container costs to build. `add` writes into the resolver map in place, so a chain is
+// linear at runtime even though it stays O(N²) to type-check; the second group checks `compose`
+// adds no runtime tax.
 import { DIContainer } from '../../DIContainer.js';
 import { buildIndependentChain, buildModules, sink } from '../__helpers__/syntheticGraph.js';
 import { bench, describe } from 'vitest';
@@ -11,7 +12,9 @@ const GRAPH_SIZE = 200;
 const MODULE_COUNT = 20;
 
 describe('add — a growing chain', () => {
-  // Doubling the size should roughly quadruple the time.
+  // Doubling the size should roughly double the time. Anything approaching a quadrupling means a
+  // rebuild of the resolver map is back on the `add` path — `resolverMapOwnership.test.ts` pins
+  // that deterministically, and is the row to look at first when this one drifts.
   for (const size of CHAIN_SIZES) {
     bench(`chain of ${size}`, () => {
       sink.value = buildIndependentChain(size);

--- a/src/__tests__/__helpers__/syntheticGraph.ts
+++ b/src/__tests__/__helpers__/syntheticGraph.ts
@@ -50,8 +50,16 @@ export const buildLinkedChain = (size: number): SyntheticContainer => {
   return container;
 };
 
-/** `size` must divide evenly. */
+/**
+ * `size` must divide evenly by `moduleCount`. A fractional `perModule` would silently produce
+ * short modules and duplicate keys across them, so the row would price a different graph than
+ * its name claims rather than fail.
+ */
 export const buildModules = (size: number, moduleCount: number): SyntheticContainer[] => {
+  if (size % moduleCount !== 0) {
+    throw new Error(`buildModules: ${size} dependencies do not divide evenly into ${moduleCount}.`);
+  }
+
   const perModule = size / moduleCount;
 
   return Array.from({ length: moduleCount }, (_, module) => {

--- a/src/__tests__/reservedNames.test.ts
+++ b/src/__tests__/reservedNames.test.ts
@@ -29,7 +29,10 @@ describe('reserved dependency names', () => {
     }
   });
 
-  test('a dependency cannot shadow export and break merge', () => {
+  // `merge` used to call `export()` on every container passed to it, so a dependency of this name
+  // turned any `merge`/`compose` into a `TypeError`. `merge` reads the protected maps directly
+  // now, but `export` is still public API, so an own property shadowing it is still a break.
+  test('a dependency cannot shadow export', () => {
     expect(() => new DIContainer().add('export' as 'notAMethod', () => 1)).toThrow(
       ForbiddenNameError,
     );

--- a/src/__tests__/resolverMapOwnership.test.ts
+++ b/src/__tests__/resolverMapOwnership.test.ts
@@ -1,0 +1,119 @@
+import { DIContainer } from '../DIContainer.js';
+import { describe, expect, test } from 'vitest';
+
+/**
+ * Exposes the protected maps so a test can assert on their identity. `add`, `update` and `merge`
+ * write into them in place, and identity is the only way to observe that from outside.
+ */
+class MapProbe extends DIContainer {
+  public get resolvedMap(): unknown {
+    return this.resolvedDependencies;
+  }
+
+  public get resolverMap(): unknown {
+    return this.resolvers;
+  }
+}
+
+/**
+ * Rebuilding the resolver map per call is what made wiring O(N²) at runtime — 1600 dependencies
+ * cost 196 ms on 3.2.1 against 0.6 ms once the writes went in place, with the per-dependency cost
+ * flat from a few hundred up.
+ *
+ * Wall clock cannot guard that in CI: it does not transfer between machines, which is why
+ * `pnpm bench` has no CI job and `bench:types` gates on instantiation counts instead. Map identity
+ * states the same invariant deterministically — a `{ ...this.resolvers }` reintroduced on any of
+ * these paths fails here rather than silently handing every consumer quadratic wiring back.
+ */
+describe('the container writes into its maps in place', () => {
+  test('a chain of add calls keeps the same resolver map', () => {
+    const probe = new MapProbe();
+    const resolverMap = probe.resolverMap;
+
+    probe
+      .add('a', () => 'a')
+      .add('b', () => 'b')
+      .add('c', () => 'c');
+
+    expect(probe.resolverMap).toBe(resolverMap);
+    expect(probe.has('c')).toBe(true);
+  });
+
+  test('update keeps the same resolver map', () => {
+    const probe = new MapProbe();
+    const container = probe.add('a', () => 'a');
+    const resolverMap = probe.resolverMap;
+
+    const updated = container.update('a', () => 'replaced');
+
+    expect(probe.resolverMap).toBe(resolverMap);
+    expect(updated.a).toEqual('replaced');
+  });
+
+  test('merge keeps both of the receiving container maps', () => {
+    const probe = new MapProbe();
+    const container = probe.add('a', () => 'a');
+    const resolvedMap = probe.resolvedMap;
+    const resolverMap = probe.resolverMap;
+
+    const merged = container.merge(new DIContainer().add('b', () => 'b'));
+
+    expect(probe.resolverMap).toBe(resolverMap);
+    expect(probe.resolvedMap).toBe(resolvedMap);
+    expect(merged.b).toEqual('b');
+  });
+
+  test('caching a resolved value keeps the same map', () => {
+    const probe = new MapProbe();
+    const container = probe.add('a', () => 'a');
+    const resolvedMap = probe.resolvedMap;
+
+    expect(container.a).toEqual('a');
+    expect(probe.resolvedMap).toBe(resolvedMap);
+  });
+});
+
+/**
+ * The flip side of those in-place writes: before them, `add` replaced `this.resolvers` outright,
+ * so whatever `export()` handed out was a de-facto snapshot that no later call could reach. Now
+ * the live map would keep changing under the caller — and let the caller change the container —
+ * so `export()` copies. Nothing inside the class goes through it; `clone` and `merge` read the
+ * protected maps directly, so no internal path pays for the copy.
+ */
+describe('export hands out copies, not the live maps', () => {
+  // `export` is declared on the class but not on `IDIContainer`, which is what `add` returns — so
+  // these hold the instance reference and use the widened one only to read values off it.
+  test('a later registration is not visible through an earlier export', () => {
+    const container = new DIContainer();
+    container.add('a', () => 'a');
+    const exported = container.export();
+
+    container.add('b', () => 'b');
+
+    expect('b' in exported.resolvers).toBe(false);
+    expect('a' in exported.resolvers).toBe(true);
+  });
+
+  test('writing into an exported map does not reach the container', () => {
+    const container = new DIContainer();
+    const typed = container.add('a', () => 'a');
+    const exported = container.export();
+
+    exported.resolvers.injected = () => 'injected';
+    exported.resolvedDependencies.a = 'tampered';
+
+    expect(container.has('injected')).toBe(false);
+    expect(typed.a).toEqual('a');
+  });
+
+  test('a later resolution is not visible through an earlier export', () => {
+    const container = new DIContainer();
+    const typed = container.add('a', () => 'a');
+    const exported = container.export();
+
+    expect(typed.a).toEqual('a');
+
+    expect('a' in exported.resolvedDependencies).toBe(false);
+    expect(container.hasResolvedDependency('a')).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,14 @@
-import { defineConfig } from 'vitest/config';
+import { defaultExclude, defineConfig } from 'vitest/config';
 
 // `tsc` compiles the tests and benchmarks along with the sources, so every file under `src/` has a
 // compiled twin under `dist/`. Vitest 4 dropped `**/dist/**` from its default excludes, which left
 // each suite running twice — the second time against whatever the last build emitted. That is
 // harmless when the two agree and quietly misleading when they do not: benchmark runs reported two
 // sets of numbers for the same name, and a stale `dist/` could pass a suite the sources fail.
-const EXCLUDE = ['**/node_modules/**', '**/dist/**'];
+//
+// Extended rather than replaced: spelling the list out drops whatever Vitest excludes by default
+// (`**/.git/**` today), which is a silent narrowing that has nothing to do with the `dist/` fix.
+const EXCLUDE = [...defaultExclude, '**/dist/**'];
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
Follow-ups to #17. That PR's core change is right and the win is real — I measured a chain of 1600 dependencies at 196 ms before and 0.6 ms after, with the per-dependency cost flat from a few hundred up. These are the loose ends around it.

## `export()` was silently changed

#17 says "no public API or type changes." One slipped through.

`add` used to replace `this.resolvers` outright, so whatever `export()` returned was a de-facto snapshot that no later call could reach. Once the writes went in place it became a live handle:

```
export() snapshot sees later add("b"): true
writing to exported map affects container: true
```

A caller could watch the container change under them, and mutate it by writing into what they were given.

`export()` copies both maps now, restoring the pre-#17 semantics. Nothing inside the class pays for it — `clone()` and `merge()` read the protected maps directly, cross-instance, which is one small allocation *less* per call than routing through `export()` was.

The other option was a second internal accessor. Removing a call site beat adding one: `addContainerProperty` defines dependencies as own properties, so every method name is shadowable by a dependency of the same name, and a new private method widens that surface.

**Noticed while writing the tests:** `export` is declared on the class but **not** on `IDIContainer`, which is what `add` returns — so `container.add(...).export()` does not type-check, and the method is unreachable for anyone who chains. That is the drift AGENTS.md warns about under "the type and the class are two parallel definitions." Pre-existing, left as found, recorded in AGENTS.md — putting it on the interface is an API decision, not a fix.

## The perf win had nothing guarding it

Rebuilding either map is a performance bug now, not a style choice, but nothing in the normal test run notices: `pnpm bench` is deliberately not a CI job, because wall clock does not transfer between machines.

`bench:types` already answers that for the type-level cost by gating on instantiation counts instead of time. `resolverMapOwnership.test.ts` is the runtime analogue — `add`, `update`, `merge` and a cached `get` all keep the same map object, so a `{ ...this.resolvers }` reintroduced anywhere on those paths fails deterministically instead of quietly costing every consumer quadratic wiring again.

Verified load-bearing by reverting each fix in turn:

```
export() live again:      3 failed | 4 passed
add() spreading again:    2 failed | 5 passed
```

(The `merge` row survives the `add` revert, correctly — they are independent write paths.)

## Three smaller things

- **`wiring.bench.ts` described the code #17 deleted.** The header said "`add` copies the resolver map per call, so a chain is O(N²) at runtime too", and the group comment said "doubling the size should roughly quadruple the time." Both now say linear, which inverts what a passing run means to the next reader. Measured ratio is ~4.1x across a 4x size increase; a rebuild would put it near 16x.
- **`vitest.config.ts` narrowed the excludes.** It spelled the list out in full, dropping whatever Vitest excludes by default (`**/.git/**` today). Extends `defaultExclude` now — the `dist/` fix should not quietly change anything else.
- **`buildModules` documented a precondition it did not check.** A non-divisible `size` silently built short modules with duplicate keys, pricing a different graph than the row name claims. It throws now.

## Checks

`pnpm build`, `pnpm test` (9 files / 57 tests), `pnpm lint` and `pnpm bench:types` all pass; type budgets unmoved at 73–81%.

No public API or type changes — `export()`'s return shape is unchanged, only its aliasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)