### PR TITLE
feat: compare benchmarks against the last released tag during release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Prepare and cut a new release of the rsdi package — verify the build/lint/tests are green, decide the semver bump from the actual API changes, write the CHANGELOG entry, and run `pnpm version`. Use this whenever the user wants to bump the version, cut or prepare a release, ship a new version, tag a release, or asks "what version should this be?" — including when they only say something like "let's release this" or "time to publish" without naming a version number.
+description: Prepare and cut a new release of the rsdi package — verify the build/lint/tests are green, compare benchmarks against the last released tag to catch any performance regression, decide the semver bump from the actual API changes, write the CHANGELOG entry, and run `pnpm version`. Use this whenever the user wants to bump the version, cut or prepare a release, ship a new version, tag a release, or asks "what version should this be?" — including when they only say something like "let's release this" or "time to publish" without naming a version number.
 ---
 
 # Cutting an rsdi release
@@ -72,7 +72,62 @@ modified with no commit and no tag (see Gotchas). Finding out here is cheaper.
 `pnpm test` covers both runtime and type tests. All three must pass before you continue. If something
 fails, fix it or stop — never release around a red check.
 
-## Step 4 — Write the CHANGELOG entry
+## Step 4 — Compare performance against the last release
+
+```bash
+pnpm bench:compare
+```
+
+This builds the last released tag and the release candidate, measures both, and prints the deltas.
+It takes a couple of minutes and needs a **clean working tree**, because it switches refs in place —
+run it before you write the CHANGELOG, not after. It restores your branch on the way out, including
+when a measurement fails.
+
+Run it every time, even for a release you are sure is types-only. It is cheap relative to shipping a
+regression, and "sure" is exactly the state in which one gets through.
+
+### Reading the output
+
+Two cost models, and they earn very different amounts of trust:
+
+- **Type cost** — instantiation counts from `bench-types.mjs`. Deterministic: the same source
+  produces the same number on every machine. Any delta is real, and a flag here needs no second
+  opinion. A scenario reported as `BROKEN on the candidate` blocks the release outright.
+- **Runtime cost** — `p75` from `vitest bench`, best of alternating rounds. Wall clock, and the
+  weaker half by a wide margin. **It resolves large effects only.** A 10x wiring win is
+  unmistakable; a ~35% change does not survive a busy machine and has been observed reporting the
+  wrong _sign_. Rows whose own repeats disagree are printed as `unstable — not compared`, which
+  means unjudged, not clean. Treat this section as a smoke alarm and the type numbers as the gate.
+
+The runtime section is skipped entirely when the compiled output is identical to the baseline once
+comments are stripped. **That is a stronger result than any measurement, not a gap in coverage** — if
+the emitted JavaScript did not change, the runtime cannot have. Types-only releases normally land
+here and report nothing.
+
+### Acting on a flag
+
+| Report                                 | What to do                                                                                                                                                                            |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Type cost up >5%                       | Real. Investigate before releasing — this is the failure mode `bench:types` budgets exist to catch, and a budget with headroom will not catch a regression that still fits inside it. |
+| A scenario `BROKEN on the candidate`   | Stop. Inference degraded or a budget blew; that ships broken types to consumers.                                                                                                      |
+| Runtime row flagged `← SLOWER`         | Re-run with `BENCH_COMPARE_ROUNDS=4` on an otherwise idle machine before believing it. A single pair of runs has produced a confident +47% on a path that was actually 4× faster.     |
+| Runtime flag that survives more rounds | Probably real if it is large. Decide whether it is acceptable, then **say so in the CHANGELOG** — see below.                                                                          |
+| Several rows `unstable — not compared` | The machine is too busy for this measurement. Close what you can and re-run, or accept that runtime went unchecked and say so when handing back. Do not read it as a pass.            |
+| `no degradation`                       | Move on — bearing in mind that means "nothing large enough to detect", not "identical".                                                                                               |
+
+### Feed the result into the CHANGELOG
+
+This is why the step comes before Step 5 rather than after.
+
+- **A large improvement is consumer-visible and belongs in the entry.** "Wiring a container is no
+  longer quadratic" is exactly what someone deciding whether to upgrade wants to know.
+- **A regression you decide to accept must be disclosed, not buried.** 3.3.0 deliberately made
+  `clone()` ~35% slower to make `add` linear — a good trade, and one the entry stated plainly.
+  Someone whose workload is clone-heavy needs to be able to find that.
+- Small deltas that only move an internal counter are not consumer-visible. Leave them out, the same
+  as any other internal change.
+
+## Step 5 — Write the CHANGELOG entry
 
 Add the new section at the top of `CHANGELOG.md`, under the `# Changelog` heading. Match the existing
 shape: `# X.Y.Z` for the version, `## Added` / `## Fixed` / `## Changed` for groups, newest first.
@@ -130,7 +185,7 @@ package.
 
 Then format and re-check: `npx oxfmt CHANGELOG.md && pnpm lint`.
 
-## Step 5 — Commit the CHANGELOG
+## Step 6 — Commit the CHANGELOG
 
 ```bash
 git add CHANGELOG.md && git commit -m "docs: changelog for <version>"
@@ -139,7 +194,7 @@ git add CHANGELOG.md && git commit -m "docs: changelog for <version>"
 This is not optional housekeeping. `pnpm version` aborts on any uncommitted change, **including
 staged ones**, so a left-behind CHANGELOG edit blocks the bump entirely.
 
-## Step 6 — Bump
+## Step 7 — Bump
 
 ```bash
 pnpm version patch    # or minor / major
@@ -152,7 +207,7 @@ This bumps `package.json`, commits it with the bare version as the message (`3.1
 git log --oneline -1 && git tag --points-at HEAD
 ```
 
-## Step 7 — Hand back
+## Step 8 — Hand back
 
 Report the new version, the tag, and what the CHANGELOG says. Then stop.
 
@@ -167,6 +222,15 @@ git push && git push --tags
 
 - **`pnpm version` needs a completely clean tree.** Staged-but-uncommitted changes count as dirty and
   produce `ERR_PNPM_UNCLEAN_WORKING_TREE`. This is why the CHANGELOG is committed first.
+- **`pnpm bench:compare` also needs a clean tree**, for a different reason: it checks out the baseline
+  tag in place. It refuses rather than stashing on your behalf. If it is ever interrupted hard enough
+  to leave you on a detached HEAD, `git checkout <your-branch>` is the whole recovery — it only ever
+  touches the benchmark harness paths, and it restores those before switching back.
+- **Do not benchmark an old tag in a git worktree.** `bench-types.mjs` writes its fixtures under
+  `node_modules/.types-bench`, and they import `../../src`. A worktree typically symlinks
+  `node_modules` back to the primary checkout, so the fixture resolves to the _primary_ `src/` and
+  reports the current commit's numbers under the old tag's name. `bench:compare` switches refs in
+  place to avoid exactly this.
 - **A failing pre-commit hook leaves a half-bump.** If husky rejects the version commit, `pnpm
 version` has already written the new number into `package.json` and staged it, but there is no
   commit and no tag. Recover with `git checkout -- package.json` before retrying — otherwise the next

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Use **pnpm** (pinned via `packageManager`; do not use npm/yarn).
 | Format + autofix     | `pnpm format`                                         |
 | Type-cost budgets    | `pnpm bench:types`                                    |
 | Runtime benchmarks   | `pnpm bench` (`vitest bench --run`)                   |
+| Compare vs last tag  | `pnpm bench:compare` (release step; clean tree)       |
 
 `pnpm lint` runs `oxfmt --check` then `oxlint --type-aware --type-check`; `pnpm format` runs the same two tools in write/`--fix` mode.
 
@@ -106,6 +107,13 @@ Note this is a _type_-level cost only. The runtime `update()` path is the same i
 `pnpm bench` runs `src/__tests__/__benchmarks__/*.bench.ts` through `vitest bench`, pricing the runtime claims above: cache hits are flat in container size, wiring is linear, `compose` adds nothing. **Read each group as ratios between its own rows** — wall clock does not transfer between machines, so there are no budgets and no CI job (`docs/type-benchmarks.md` explains why).
 
 **A benchmark body must not repeat one loop-invariant call.** Resolving a fixed name in a batch lets V8 hoist the call clean out of the loop, so the row measures the optimiser instead of the container — that artefact reported a 2.7x speedup here as a 1.6x regression, in both directions, reproducibly. Vary the name per iteration, as `resolve.bench.ts` does.
+
+**`pnpm bench:compare` is the one place these numbers become a verdict.** It builds the last released tag and the current checkout, measures both with _this_ checkout's harness, and reports the deltas; the `/release` skill runs it before the CHANGELOG is written. Two things it encodes that are easy to get wrong by hand:
+
+- **It skips the runtime section when the compiled `dist/*.js` is identical bar comments.** That is a stronger claim than any timing run, and it is how a types-only release avoids reporting noise as a result. The check is `-maxdepth 1` deliberately — `tsc` also emits `dist/__tests__/**`, and folding that in makes every test-only edit look like a runtime change.
+- **It alternates the two builds across rounds and keeps the best observation of each.** One unalternated pair is not enough: during development this exact harness reported a confident `+47.6%` regression on `get()`, a path that is roughly 4x _faster_. Two rounds put it at `-26.8%`. `BENCH_COMPARE_ROUNDS` raises it when a flag looks marginal.
+
+**Its runtime half resolves large effects only, and says so.** Rows whose own repeats disagree print as `unstable — not compared`, which means unjudged rather than clean. Even a row that passes the stability check has been seen reporting the wrong sign on a ~35% change while the machine was busy. The deterministic halves — type cost and the compiled-output check — are the actual gate; the timings are a smoke alarm.
 
 ## Conventions & gotchas (read before editing)
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "bench": "vitest bench --run",
+    "bench:compare": "node scripts/bench-compare.mjs",
     "bench:types": "node scripts/bench-types.mjs",
     "build": "tsc",
     "format": "oxfmt --threads=1 && oxlint --type-aware --type-check --quiet --fix",

--- a/scripts/bench-compare.mjs
+++ b/scripts/bench-compare.mjs
@@ -1,0 +1,420 @@
+// Compares a release candidate against the last released tag, so a release never ships a
+// performance regression its author did not know about.
+//
+// Two cost models, measured differently on purpose:
+//
+//   - **Type cost** (`bench-types.mjs`) is deterministic. Instantiation counts are identical
+//     across runs and machines, so any delta is real signal and needs no statistics.
+//   - **Runtime cost** (`vitest bench`) is wall clock, and it is the weaker half. Run-to-run
+//     variance on *byte-identical* code is routinely ±10%, and rebuilding between measurements
+//     adds drift on top. This alternates the builds across rounds, reports each row's best
+//     observation, and refuses to compare a row whose own repeats disagree.
+//
+//     **It resolves large effects only.** A 10x wiring win shows up unmistakably; a ~35% change
+//     does not survive a busy machine, and has been observed reporting the wrong sign even with
+//     the stability check passing. Treat a runtime row as a smoke alarm, and the deterministic
+//     checks above as the actual gate.
+//
+// Both sides are measured with **this** commit's harness, overlaid onto the baseline checkout.
+// Otherwise a change to a fixture would be indistinguishable from a change to the library, and
+// an older tag usually has no benchmark files at all.
+//
+// Why not a git worktree: `bench-types.mjs` writes fixtures under `node_modules/.types-bench`
+// and they import `../../src`. A worktree normally symlinks `node_modules` back to the primary
+// checkout, so the fixture resolves to the *primary* `src/` and silently measures the wrong
+// commit. Switching refs in place is slower but cannot lie.
+import { execFileSync, execSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, '..');
+const tmpDir = join(repoRoot, 'node_modules', '.bench-compare');
+
+// Everything the harness needs that is not the library itself. Overlaid onto the baseline so the
+// two sides differ only in `src/`.
+const HARNESS_PATHS = [
+  'scripts/bench-types.mjs',
+  'vitest.config.ts',
+  'src/__tests__/__benchmarks__',
+  'src/__tests__/__helpers__',
+];
+
+// A runtime row has to move more than this before it is worth mentioning. Set from the observed
+// spread of repeated runs on unchanged code — below it, the number is the machine, not the code.
+const RUNTIME_NOISE_PCT = 15;
+
+// ...and a row whose own repeats disagree by more than this is not compared at all. A busy machine
+// pushes short rows well past it, which is the answer being reported: "cannot tell from here",
+// not a number. Raising the round count is the fix, or running it on a quiet machine.
+const RUNTIME_INSTABILITY_RATIO = 1.3;
+
+// Type cost is exact, so these filter trivia rather than noise: annotate anything that moved,
+// but only call it a degradation once it is big enough to be worth someone's afternoon.
+const TYPE_REPORT_PCT = 1;
+const TYPE_REGRESSION_PCT = 5;
+
+const sh = (cmd, opts = {}) =>
+  execSync(cmd, { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe', ...opts });
+
+const git = (args) => execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8' }).trim();
+
+/** Runs a command that is *expected* to sometimes fail, returning its output either way. */
+const shSoft = (cmd) => {
+  try {
+    return { ok: true, out: sh(cmd) };
+  } catch (error) {
+    return { ok: false, out: `${error.stdout ?? ''}${error.stderr ?? ''}` };
+  }
+};
+
+const parseTypeBench = (output) => {
+  const scenarios = new Map();
+  for (const line of output.split('\n')) {
+    const match = /^\s*([✓✗])\s+(\S+)\s+—\s+([\d,]+)\s*\/\s*([\d,]+)\s+instantiations/u.exec(line);
+    if (match) {
+      scenarios.set(match[2], {
+        budget: Number(match[4].replaceAll(',', '')),
+        instantiations: Number(match[3].replaceAll(',', '')),
+        ok: match[1] === '✓',
+      });
+      continue;
+    }
+
+    // A scenario that broke inference reports no number at all.
+    const failed = /^\s*✗\s+(\S+)\s+—/u.exec(line);
+    if (failed && !scenarios.has(failed[1])) {
+      scenarios.set(failed[1], { budget: null, instantiations: null, ok: false });
+    }
+  }
+
+  return scenarios;
+};
+
+/**
+ * The shipped library's executable output, with comments and blank lines stripped.
+ *
+ * `-maxdepth 1` on purpose: `tsc` also emits `dist/__tests__/**`, and folding that in makes any
+ * test-only change look like a runtime change, which defeats the entire fast path. This matches
+ * what `package.json#files` actually publishes.
+ */
+const runtimeShape = () => {
+  const dist = join(repoRoot, 'dist');
+  if (!existsSync(dist)) {
+    return null;
+  }
+
+  return sh(`find ${dist} -maxdepth 1 -name '*.js' | sort | xargs cat`)
+    .replaceAll(/\/\*[\S\s]*?\*\//gu, '')
+    .replaceAll(/^\s*\/\/.*$/gmu, '')
+    .replaceAll(/^\s*$\n/gmu, '');
+};
+
+const measureTypes = () => {
+  const result = shSoft('node scripts/bench-types.mjs');
+  return parseTypeBench(result.out);
+};
+
+const measureRuntime = (label, round) => {
+  const outFile = join(tmpDir, `${label}-${round}.json`);
+  const result = shSoft(`npx vitest bench --run --outputJson ${outFile}`);
+  if (!existsSync(outFile)) {
+    return { error: result.out.split('\n').slice(-6).join('\n'), rows: new Map() };
+  }
+
+  const rows = new Map();
+  for (const file of JSON.parse(readFileSync(outFile, 'utf8')).files ?? []) {
+    for (const group of file.groups ?? []) {
+      for (const bench of group.benchmarks ?? []) {
+        // p75, not mean: a GC pause inside one sample moves the mean by orders of magnitude and
+        // leaves p75 untouched. Lower is better — these are milliseconds per iteration.
+        rows.set(`${group.fullName} › ${bench.name}`, bench.p75);
+      }
+    }
+  }
+
+  return { error: null, rows };
+};
+
+/** Accumulates every observation per row, so the reporter can judge how stable the row was. */
+const collect = (into, rows) => {
+  for (const [name, value] of rows) {
+    if (!into.has(name)) {
+      into.set(name, []);
+    }
+
+    into.get(name).push(value);
+  }
+
+  return into;
+};
+
+/**
+ * A row's best observation, and how far its worst was from it.
+ *
+ * The spread is the honest half. A row whose own repeats disagree cannot support a claim about the
+ * difference *between* builds, and reporting one anyway is how this tool briefly insisted that
+ * `clone a built container` was 36.8% faster: the baseline measured 0.0265 in one run and 0.0799
+ * in the next — same commit — so the delta was decided by which pairing happened to come up. The
+ * true figure is roughly 35% *slower*.
+ */
+const summarise = (values) => {
+  const min = Math.min(...values);
+  return { min, spread: Math.max(...values) / min };
+};
+
+/**
+ * Copies the candidate's harness aside before any ref switch, so it can be laid over an older
+ * checkout that may not contain those files at all.
+ *
+ * Deliberately plain file copies rather than `git checkout <ref> -- <path>`: that stages the
+ * paths, and unstaging one that does not exist at the baseline leaves it untracked, which then
+ * blocks the checkout back with "untracked working tree files would be overwritten". Owning the
+ * copies outright means cleanup is `rm`, which cannot half-succeed.
+ */
+const snapshotHarness = () => {
+  const snapshot = join(tmpDir, 'harness');
+  for (const path of HARNESS_PATHS) {
+    const source = join(repoRoot, path);
+    if (existsSync(source)) {
+      cpSync(source, join(snapshot, path), { force: true, recursive: true });
+    }
+  }
+};
+
+const applyHarness = () => {
+  const snapshot = join(tmpDir, 'harness');
+  for (const path of HARNESS_PATHS) {
+    const source = join(snapshot, path);
+    if (existsSync(source)) {
+      cpSync(source, join(repoRoot, path), { force: true, recursive: true });
+    }
+  }
+};
+
+/**
+ * Undoes the overlay at file granularity. Tracking it at *path* granularity is not enough: a
+ * directory such as `src/__tests__/__helpers__` exists at the baseline while a file inside it
+ * does not, so "the directory already existed" left the added file behind — untracked, which
+ * then blocks the checkout back. `git clean` scoped to each path settles it per file.
+ *
+ * Safe because startup refuses to run on a dirty tree, so nothing under these paths can be the
+ * user's own work.
+ */
+const removeHarness = () => {
+  for (const path of HARNESS_PATHS) {
+    shSoft(`git checkout --quiet -- ${path}`);
+    shSoft(`git clean -qfd -- ${path}`);
+  }
+};
+
+const pct = (from, to) => ((to - from) / from) * 100;
+
+const fmtPct = (value) => `${value >= 0 ? '+' : ''}${value.toFixed(1)}%`;
+
+const main = () => {
+  // Two is the floor, not a default to tune down: one observation per side has no spread, so
+  // the stability check silently passes everything and the numbers go back to being guesses.
+  const rounds = Math.max(2, Number(process.env.BENCH_COMPARE_ROUNDS ?? 2));
+
+  if (git(['status', '--porcelain'])) {
+    console.error(
+      'bench-compare: the working tree must be clean — this switches refs in place.\n' +
+        'Commit or stash first; refusing rather than stashing on your behalf.',
+    );
+    process.exit(1);
+  }
+
+  const baseline = process.argv[2] ?? git(['describe', '--tags', '--abbrev=0']);
+  // A branch name where there is one, so the restore puts the branch back rather than detaching.
+  const candidate =
+    shSoft('git symbolic-ref --quiet --short HEAD').out.trim() || git(['rev-parse', 'HEAD']);
+
+  console.log(`bench-compare: ${baseline} (baseline) vs ${candidate} (candidate)\n`);
+
+  rmSync(tmpDir, { force: true, recursive: true });
+  mkdirSync(tmpDir, { recursive: true });
+
+  const types = {};
+  const runtime = { baseline: new Map(), candidate: new Map() };
+  const shape = {};
+  let comparable = true;
+
+  snapshotHarness();
+
+  try {
+    // Round 0 is a probe: it establishes the type numbers and the compiled shape, and therefore
+    // whether timing anything is worthwhile at all. Rounds 1..n are runtime only, alternating
+    // sides so that drift in machine state lands on both rather than on whichever ran second.
+    for (let round = 0; round <= rounds; round++) {
+      for (const side of ['candidate', 'baseline']) {
+        const ref = side === 'baseline' ? baseline : candidate;
+        git(['checkout', '--quiet', ref]);
+        if (side === 'baseline') {
+          applyHarness();
+        }
+
+        sh('npx tsc');
+
+        if (round === 0) {
+          shape[side] = runtimeShape();
+          types[side] = measureTypes();
+
+          // Only worth timing if the executable output actually differs.
+          if (side === 'baseline' && shape.candidate && shape.baseline === shape.candidate) {
+            comparable = false;
+          }
+        }
+
+        if (comparable && round > 0) {
+          const measured = measureRuntime(side, round);
+          if (measured.error && round === 1) {
+            console.log(`  (runtime benchmark did not run at ${ref}: ${measured.error})\n`);
+          }
+
+          collect(runtime[side], measured.rows);
+        }
+
+        if (side === 'baseline') {
+          removeHarness();
+        }
+      }
+
+      if (!comparable) {
+        break;
+      }
+    }
+  } finally {
+    // Order matters: the overlay has to go before the checkout, or git refuses to switch back
+    // over untracked files it would overwrite. This ran on a real failure once already.
+    removeHarness();
+    shSoft(`git checkout --force --quiet ${candidate}`);
+    shSoft('npx tsc');
+  }
+
+  const regressions = [];
+  const unstable = [];
+
+  console.log('Type cost — instantiations (deterministic, any delta is real)\n');
+  const names = new Set([...types.candidate.keys(), ...types.baseline.keys()]);
+  for (const name of [...names].sort()) {
+    const base = types.baseline.get(name);
+    const cand = types.candidate.get(name);
+
+    if (!base) {
+      console.log(
+        `  ${name.padEnd(22)} new scenario — ${cand.instantiations?.toLocaleString() ?? 'FAILED'}`,
+      );
+      continue;
+    }
+
+    if (!cand) {
+      console.log(`  ${name.padEnd(22)} removed`);
+      continue;
+    }
+
+    // A scenario the baseline could not compile is the release fixing something, not a regression.
+    if (!base.ok || !cand.ok) {
+      const verdict = cand.ok ? 'FIXED (baseline broke inference)' : 'BROKEN on the candidate';
+      console.log(`  ${name.padEnd(22)} ${verdict}`);
+      if (!cand.ok) {
+        regressions.push(`${name} breaks inference or exceeds its budget`);
+      }
+
+      continue;
+    }
+
+    const delta = pct(base.instantiations, cand.instantiations);
+    const flag = Math.abs(delta) < TYPE_REPORT_PCT ? '' : delta > 0 ? '  ← worse' : '  ← better';
+    console.log(
+      `  ${name.padEnd(22)} ${base.instantiations.toLocaleString().padStart(9)} → ` +
+        `${cand.instantiations.toLocaleString().padStart(9)}  ${fmtPct(delta).padStart(7)}` +
+        `  (${Math.round((cand.instantiations / cand.budget) * 100)}% of budget)${flag}`,
+    );
+
+    if (delta > TYPE_REGRESSION_PCT) {
+      regressions.push(`${name} costs ${fmtPct(delta)} more to type-check`);
+    }
+  }
+
+  console.log('\nRuntime cost — p75 ms per iteration, best of alternating rounds\n');
+  if (!comparable) {
+    console.log(
+      '  Compiled output is identical to the baseline once comments are stripped.\n' +
+        '  Runtime cannot have changed; skipped rather than reporting noise as a result.',
+    );
+  } else if (runtime.baseline.size === 0) {
+    console.log(
+      '  No baseline measurement — the harness did not run at the baseline ref (see above).',
+    );
+  } else {
+    for (const name of [...runtime.candidate.keys()].sort()) {
+      const baseValues = runtime.baseline.get(name);
+      const candValues = runtime.candidate.get(name);
+      if (baseValues === undefined) {
+        console.log(`  ${name}  new row`);
+        continue;
+      }
+
+      const base = summarise(baseValues);
+      const cand = summarise(candValues);
+      const worstSpread = Math.max(base.spread, cand.spread);
+
+      // Refuse to compare a row that cannot reproduce itself. Reporting a delta computed from
+      // observations that disagree by more than the delta is how a benchmark lies with a
+      // straight face — and this one did exactly that before the check existed.
+      if (worstSpread > RUNTIME_INSTABILITY_RATIO) {
+        console.log(
+          `  ${name}\n      unstable — its own repeats span x${worstSpread.toFixed(1)}; not compared`,
+        );
+        unstable.push(name);
+        continue;
+      }
+
+      const delta = pct(base.min, cand.min);
+      const flag =
+        Math.abs(delta) < RUNTIME_NOISE_PCT
+          ? '  (within noise)'
+          : delta > 0
+            ? '  ← SLOWER'
+            : '  ← faster';
+      console.log(
+        `  ${name}\n      ${base.min.toFixed(4)} → ${cand.min.toFixed(4)}  ${fmtPct(delta).padStart(7)}${flag}`,
+      );
+
+      if (delta > RUNTIME_NOISE_PCT) {
+        regressions.push(
+          `${name} is ${fmtPct(delta)} slower (above the ${RUNTIME_NOISE_PCT}% noise floor)`,
+        );
+      }
+    }
+  }
+
+  console.log('');
+  if (unstable.length > 0) {
+    console.log(
+      `bench-compare: ${unstable.length} runtime row(s) too unstable to compare on this machine.\n` +
+        'Those rows are unjudged, not clean — re-run with BENCH_COMPARE_ROUNDS=4 on a quiet\n' +
+        'machine if the release touches what they measure.\n',
+    );
+  }
+
+  if (regressions.length === 0) {
+    console.log(`bench-compare: no degradation against ${baseline}`);
+    return;
+  }
+
+  console.log(`bench-compare: ${regressions.length} possible degradation(s) against ${baseline}\n`);
+  for (const line of regressions) {
+    console.log(`  - ${line}`);
+  }
+
+  console.log(
+    '\nA runtime flag near the noise floor is worth re-running before believing — pass\n' +
+      'BENCH_COMPARE_ROUNDS=4 for more rounds. A type-cost flag needs no second opinion.',
+  );
+  process.exitCode = 1;
+};
+
+main();


### PR DESCRIPTION
Nothing currently stops a release shipping a performance regression. Both benchmark suites measure only the *current* checkout, so a regression is visible only to whoever thought to record the old numbers first — and #17 shipped a deliberate ~34% `clone()` regression that would have gone unnoticed had its author not measured by hand.

`pnpm bench:compare` builds the last released tag and the current checkout, measures both with **this** checkout's harness, and reports the deltas. `/release` runs it as step 4, before the CHANGELOG is written rather than after, because the result belongs in the entry.

## The two halves are not equally trustworthy, and the output says so

**The deterministic half is the gate.** Instantiation counts are identical across runs and machines, so any delta is real. So is the compiled-output check: when `dist/*.js` is identical bar comments, the runtime section is skipped entirely — a stronger claim than any timing run, and how a types-only release avoids reporting noise as a result.

**The runtime half is a smoke alarm.** It alternates the builds across rounds, keeps each row's best observation, and refuses to compare a row whose own repeats disagree. It still resolves large effects only, and the docs say that plainly rather than implying a precision the method lacks.

That wording is not caution for its own sake — it is what testing produced:

| rounds | what it reported for `get()` | truth |
| --- | --- | --- |
| 1 | **+47.6% regression** | ~4x *faster* |
| 2 | −26.8% | ✓ |

And `clone a built container`, whose true value is ~+34% slower, was reported at `+36.2%` in one run and `−36.8%` in the next — the baseline row measured `0.0265` and `0.0799` on identical code. That is why rows now print `unstable — not compared` when they cannot reproduce themselves, and why the minimum round count is hard-floored at 2. At `BENCH_COMPARE_ROUNDS=4` it lands on `+33.8%`, matching an independent hand measurement.

## Three bugs found by running it rather than reasoning about it

- **Left the repo on a detached HEAD.** Overlay cleanup used `git checkout <ref> -- <path>`, which stages the path; unstaging one absent from the baseline left it untracked, which then blocked the checkout back. Cleanup now owns its copies outright.
- **Cleanup tracked paths at directory granularity.** `src/__tests__/__helpers__` exists at the baseline while `syntheticGraph.ts` inside it does not, so "the directory already existed" left the added file behind.
- **The fast path hashed compiled test output.** `tsc` also emits `dist/__tests__/**`, so any test-only change looked like a runtime change and defeated the skip entirely. Now `-maxdepth 1`, matching what `package.json#files` publishes.

## Why refs switch in place rather than in a worktree

`bench-types.mjs` writes fixtures under `node_modules/.types-bench` that import `../../src`. A worktree symlinks `node_modules` back to the primary checkout, so those fixtures resolve to the *primary* `src/` and report the current commit's numbers under the old tag's name. Documented in the skill's gotchas, since it is the obvious approach and it fails silently.

The script requires a clean tree, refuses rather than stashing on your behalf, and restores the original branch on the way out including when a measurement throws.

## Checks

`pnpm build`, `pnpm test` (9 files / 61 tests) and `pnpm lint` pass. No `src/` changes — this is tooling and documentation only, so nothing here affects the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)